### PR TITLE
feat: TTS APIをVoice Clone方式に更新

### DIFF
--- a/frontend/src/api/ttsApi.ts
+++ b/frontend/src/api/ttsApi.ts
@@ -1,13 +1,12 @@
-interface TTSRequest {
+interface VoiceCloneRequest {
+  audio_file: File
   input: string
-  response_format?: "wav" | "mp3"
+  ref_text: string
   speed?: number
 }
 
-interface TTSResponse {
+interface VoiceCloneResponse {
   audio_data: string
-  format: string
-  sample_rate: number
 }
 
 interface TTSErrorResponse {
@@ -17,13 +16,18 @@ interface TTSErrorResponse {
 
 const API_BASE_URL = "http://localhost:8001"
 
-export const textToSpeech = async (request: TTSRequest): Promise<TTSResponse> => {
-  const response = await fetch(`${API_BASE_URL}/api/tts/synthesize`, {
+export const voiceClone = async (
+  request: VoiceCloneRequest,
+): Promise<VoiceCloneResponse> => {
+  const formData = new FormData()
+  formData.append("audio_file", request.audio_file)
+  formData.append("input", request.input)
+  formData.append("ref_text", request.ref_text)
+  formData.append("speed", (request.speed || 1.0).toString())
+
+  const response = await fetch(`${API_BASE_URL}/api/tts/voice-clone`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(request),
+    body: formData,
   })
 
   if (!response.ok) {

--- a/frontend/src/components/chat/TTSSettings.tsx
+++ b/frontend/src/components/chat/TTSSettings.tsx
@@ -1,0 +1,115 @@
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+
+interface TTSSettingsProps {
+  audioFile: File | null
+  setAudioFile: (file: File | null) => void
+  refText: string
+  setRefText: (text: string) => void
+  speed: number
+  setSpeed: (speed: number) => void
+  ttsEnabled: boolean
+  setTtsEnabled: (enabled: boolean) => void
+}
+
+export function TTSSettings({
+  audioFile,
+  setAudioFile,
+  refText,
+  setRefText,
+  speed,
+  setSpeed,
+  ttsEnabled,
+  setTtsEnabled,
+}: TTSSettingsProps) {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    if (!file.name.match(/\.(wav|mp3)$/i)) {
+      alert("WAVまたはMP3ファイルを選択してください")
+      e.target.value = ""
+      return
+    }
+
+    setAudioFile(file)
+  }
+
+  const handleRemoveFile = () => {
+    setAudioFile(null)
+    setTtsEnabled(false)
+  }
+
+  const handleToggleTTS = () => {
+    if (!audioFile || !refText.trim()) {
+      alert("参照音声ファイルとテキスト書き起こしを設定してください")
+      return
+    }
+    setTtsEnabled(!ttsEnabled)
+  }
+
+  return (
+    <div className="flex flex-col gap-3 p-4 bg-gray-50 border-t border-b">
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="tts-enabled"
+          checked={ttsEnabled}
+          onChange={handleToggleTTS}
+          className="h-4 w-4"
+        />
+        <label htmlFor="tts-enabled" className="text-sm font-medium">
+          TTS（音声合成）を有効化
+        </label>
+      </div>
+
+      {!audioFile && !refText && (
+        <div className="text-sm text-gray-600 bg-blue-50 p-2 rounded">
+          TTSを使用するには、参照音声ファイルとその書き起こしテキストを設定してください
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">参照音声ファイル</label>
+        {audioFile ? (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-700 flex-1">{audioFile.name}</span>
+            <Button variant="outline" size="sm" onClick={handleRemoveFile}>
+              削除
+            </Button>
+          </div>
+        ) : (
+          <input
+            type="file"
+            accept=".wav,.mp3"
+            onChange={handleFileChange}
+            className="text-sm"
+          />
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">参照音声の書き起こし</label>
+        <Textarea
+          placeholder="参照音声のテキスト書き起こしを入力してください"
+          value={refText}
+          onChange={(e) => setRefText(e.target.value)}
+          className="min-h-[60px]"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">再生速度: {speed.toFixed(1)}x</label>
+        <input
+          type="range"
+          min="0.5"
+          max="2.0"
+          step="0.1"
+          value={speed}
+          onChange={(e) => setSpeed(parseFloat(e.target.value))}
+          className="w-full"
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -2,13 +2,22 @@ import { useState } from "react"
 import { createChatCompletion, type Message } from "@/api/chatApi"
 import { useTTS } from "./useTTS"
 
-export function useChat() {
+interface UseChatOptions {
+  ttsConfig?: {
+    audioFile: File | null
+    refText: string
+    speed: number
+    enabled: boolean
+  }
+}
+
+export function useChat(options?: UseChatOptions) {
   const [messages, setMessages] = useState<Message[]>([])
   const [inputText, setInputText] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const { speak, isGenerating: isGeneratingAudio } = useTTS()
 
-  const sendMessage = async (enableTTS = true) => {
+  const sendMessage = async () => {
     if (!inputText.trim()) return
 
     const userMessage: Message = {
@@ -31,8 +40,18 @@ export function useChat() {
       }
       setMessages((prev) => [...prev, aiMessage])
 
-      if (enableTTS && aiMessage.content) {
-        speak(aiMessage.content).catch(console.error)
+      const ttsConfig = options?.ttsConfig
+      if (
+        ttsConfig?.enabled &&
+        ttsConfig.audioFile &&
+        ttsConfig.refText.trim() &&
+        aiMessage.content
+      ) {
+        speak(aiMessage.content, {
+          audioFile: ttsConfig.audioFile,
+          refText: ttsConfig.refText,
+          speed: ttsConfig.speed,
+        }).catch(console.error)
       }
     } catch (error) {
       console.error("チャット送信エラー:", error)

--- a/frontend/src/hooks/useTTS.ts
+++ b/frontend/src/hooks/useTTS.ts
@@ -1,11 +1,11 @@
 import { useCallback, useState } from "react"
-import { textToSpeech } from "@/api/ttsApi"
+import { voiceClone } from "@/api/ttsApi"
 
 export function useTTS() {
   const [isGenerating, setIsGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const playAudio = useCallback((audioData: string, format: string) => {
+  const playAudio = useCallback((audioData: string) => {
     const byteCharacters = atob(audioData)
     const byteNumbers = new Array(byteCharacters.length)
     for (let i = 0; i < byteCharacters.length; i++) {
@@ -13,9 +13,7 @@ export function useTTS() {
     }
     const byteArray = new Uint8Array(byteNumbers)
 
-    const mimeType = format === "wav" ? "audio/wav" : "audio/mpeg"
-
-    const blob = new Blob([byteArray], { type: mimeType })
+    const blob = new Blob([byteArray], { type: "audio/wav" })
     const url = URL.createObjectURL(blob)
 
     const audio = new Audio(url)
@@ -27,8 +25,9 @@ export function useTTS() {
   const speak = useCallback(
     async (
       text: string,
-      options?: {
-        format?: "wav" | "mp3"
+      options: {
+        audioFile: File
+        refText: string
         speed?: number
       },
     ) => {
@@ -36,12 +35,13 @@ export function useTTS() {
       setError(null)
 
       try {
-        const response = await textToSpeech({
+        const response = await voiceClone({
+          audio_file: options.audioFile,
           input: text,
-          response_format: options?.format || "mp3",
-          speed: options?.speed || 1.0,
+          ref_text: options.refText,
+          speed: options.speed || 1.0,
         })
-        playAudio(response.audio_data, response.format)
+        playAudio(response.audio_data)
       } catch (err) {
         const errorMessage =
           err instanceof Error ? err.message : "音声生成に失敗しました。"

--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react"
 import { createFileRoute } from "@tanstack/react-router"
 import { AvatarDisplay } from "@/components/chat/AvatarDisplay"
 import { ChatInput } from "@/components/chat/ChatInput"
 import { ChatMessageList } from "@/components/chat/ChatMessageList"
+import { TTSSettings } from "@/components/chat/TTSSettings"
 import { useChat } from "@/hooks/useChat"
 
 export const Route = createFileRoute("/chat")({
@@ -9,12 +11,34 @@ export const Route = createFileRoute("/chat")({
 })
 
 function RouteComponent() {
-  const { messages, inputText, setInputText, isLoading, sendMessage } = useChat()
+  const [audioFile, setAudioFile] = useState<File | null>(null)
+  const [refText, setRefText] = useState("")
+  const [speed, setSpeed] = useState(1.0)
+  const [ttsEnabled, setTtsEnabled] = useState(false)
+
+  const { messages, inputText, setInputText, isLoading, sendMessage } = useChat({
+    ttsConfig: {
+      audioFile,
+      refText,
+      speed,
+      enabled: ttsEnabled,
+    },
+  })
 
   return (
     <div className="flex h-screen">
       <div className="w-2/3 flex flex-col">
         <AvatarDisplay />
+        <TTSSettings
+          audioFile={audioFile}
+          setAudioFile={setAudioFile}
+          refText={refText}
+          setRefText={setRefText}
+          speed={speed}
+          setSpeed={setSpeed}
+          ttsEnabled={ttsEnabled}
+          setTtsEnabled={setTtsEnabled}
+        />
         <ChatInput
           value={inputText}
           onChange={setInputText}


### PR DESCRIPTION
## 概要
tts-serverの新しいVoice Clone APIに対応するため、フロントエンドのTTS機能を更新しました。

## 変更内容

### API層の変更
- エンドポイントを `/api/tts/synthesize` から `/api/tts/voice-clone` に変更
- リクエスト形式を JSON から multipart/form-data に変更
- 新しい型定義を追加: `VoiceCloneRequest`, `VoiceCloneResponse`

### UI層の追加
- **TTSSettings.tsx** を新規作成
  - 参照音声ファイルのアップロード機能（WAV/MP3対応）
  - 参照音声の書き起こしテキスト入力
  - 再生速度調整スライダー（0.5～2.0倍速）
  - TTS有効/無効トグル
  - ファイル形式とテキストのバリデーション

### Hooks層の変更
- `useTTS.speak()`: 参照音声ファイルとref_textを必須パラメータに追加
- `useTTS.playAudio()`: 音声フォーマットをWAV固定に変更
- `useChat`: TTS設定を受け取り、条件を満たす場合のみTTSを実行

### その他の変更
- `chat.tsx`: TTS設定の状態管理を追加し、TTSSettingsコンポーネントを配置

## テスト方法

### 正常系
1. チャット画面を開く
2. TTSSettingsで参照音声ファイル（WAV/MP3）をアップロード
3. 参照音声の書き起こしテキストを入力
4. 「TTS（音声合成）を有効化」チェックボックスをONにする
5. チャットメッセージを送信
6. AIの応答が音声で再生されることを確認

### 異常系
1. 参照音声未設定でTTSを有効化 → アラートが表示されることを確認
2. ref_text未入力でTTSを有効化 → アラートが表示されることを確認

## 関連ファイル
- `frontend/src/api/ttsApi.ts`
- `frontend/src/hooks/useTTS.ts`
- `frontend/src/hooks/useChat.ts`
- `frontend/src/routes/chat.tsx`
- `frontend/src/components/chat/TTSSettings.tsx` (新規)

🤖 Generated with [Claude Code](https://claude.com/claude-code)