### PR TITLE
chore: .gitignoreに.claudeディレクトリを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ nohup.out
 # uv.lock
 # package-lock.json
 # package.json
+
+# Claude Code
+.claude


### PR DESCRIPTION
## Summary
- Claude Codeのローカル設定ディレクトリ(`.claude`)を`.gitignore`に追加
- 個人のClaude Code設定がリポジトリにコミットされることを防止

## Test plan
- [x] `.claude` ディレクトリが `git status` に表示されないことを確認