### PR TITLE
ci: TTS Serverのカバレッジバッジを追加

### DIFF
--- a/.github/workflows/test-tts-server.yml
+++ b/.github/workflows/test-tts-server.yml
@@ -51,3 +51,25 @@ jobs:
       - name: Coverage report
         working-directory: tts-server
         run: uv run coverage report
+
+      - name: Extract coverage percentage
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+        id: coverage
+        working-directory: tts-server
+        run: |
+          COVERAGE=$(uv run coverage report --format=total)
+          echo "total=${COVERAGE}" >> "$GITHUB_OUTPUT"
+          echo "Coverage: ${COVERAGE}%"
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: ac2cfc2237210a437cb17a73d5d4c2a3
+          filename: tts-server-coverage.json
+          label: "coverage: tts-server"
+          message: "${{ steps.coverage.outputs.total }}%"
+          valColorRange: ${{ steps.coverage.outputs.total }}
+          minColorRange: 0
+          maxColorRange: 100

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AnotherMe - AI Avatar Platform
 
+[![TTS Server Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Rx-K8/ac2cfc2237210a437cb17a73d5d4c2a3/raw/tts-server-coverage.json)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-tts-server.yml)
+
 A monorepo containing the full AnotherMe platform: Frontend, Chat Server, and TTS Server.
 
 ## Project Structure


### PR DESCRIPTION
## Summary
- TTS Serverのテストカバレッジ率をREADMEにバッジとして表示
- `schneegans/dynamic-badges-action` を使い、main/developプッシュ時にGistへカバレッジ率を書き込み、shields.ioでバッジを生成
- 将来的に他プロジェクト（chat-server等）にも同じパターンで拡張可能

## Test plan
- [ ] `GIST_TOKEN` シークレットがリポジトリに登録済みであること
- [ ] mainマージ後、CIが実行されGistに `tts-server-coverage.json` が書き込まれること
- [ ] READMEのバッジにカバレッジ率が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)