### PR TITLE
ci: PyTorchのCPU/GPU版をextrasで切り替え可能にする

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -20,7 +20,7 @@ jobs:
         run: uv python install
 
       - name: Setup all projects
-        run: ./scripts/setup.sh
+        run: ./scripts/setup.sh --ci
 
       - name: Run test-all
         run: ./scripts/test-all.sh

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -23,4 +23,4 @@ jobs:
         run: ./scripts/setup.sh --ci
 
       - name: Run test-all
-        run: ./scripts/test-all.sh
+        run: ./scripts/test-all.sh --ci

--- a/.github/workflows/test-tts-server.yml
+++ b/.github/workflows/test-tts-server.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: tts-server
-        run: uv sync --group dev
+        run: uv sync --extra cpu --group dev
 
       - name: Run tests
         working-directory: tts-server

--- a/.github/workflows/test-tts-server.yml
+++ b/.github/workflows/test-tts-server.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run tests
         working-directory: tts-server
-        run: uv run pytest tests/ -v --tb=short --cov --cov-report=term-missing --cov-report=html
+        run: uv run --extra cpu pytest tests/ -v --tb=short --cov --cov-report=term-missing --cov-report=html
 
       - name: Store coverage files
         uses: actions/upload-artifact@v4
@@ -55,14 +55,14 @@ jobs:
 
       - name: Coverage report
         working-directory: tts-server
-        run: uv run coverage report
+        run: uv run --extra cpu coverage report
 
       - name: Extract coverage percentage
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
         id: coverage
         working-directory: tts-server
         run: |
-          COVERAGE=$(uv run coverage report --format=total)
+          COVERAGE=$(uv run --extra cpu coverage report --format=total)
           echo "total=${COVERAGE}" >> "$GITHUB_OUTPUT"
           echo "Coverage: ${COVERAGE}%"
 

--- a/chat-server/app/api/main.py
+++ b/chat-server/app/api/main.py
@@ -1,6 +1,5 @@
-from fastapi import APIRouter
-
 from app.api.routes import chat, health
+from fastapi import APIRouter
 
 api_router = APIRouter()
 

--- a/chat-server/app/api/routes/chat.py
+++ b/chat-server/app/api/routes/chat.py
@@ -1,6 +1,3 @@
-from fastapi import APIRouter, Depends
-from fastapi.responses import StreamingResponse
-
 from app.api.utils.sse import stream_as_sse
 from app.core.dependencies import get_chat_service
 from app.schemas.chat import (
@@ -8,6 +5,8 @@ from app.schemas.chat import (
     ChatCompletionResponse,
 )
 from app.services.chat_server import ChatServe
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
 
 router = APIRouter(prefix="/chat", tags=["Chat"])
 

--- a/chat-server/pyproject.toml
+++ b/chat-server/pyproject.toml
@@ -9,9 +9,17 @@ dependencies = [
     "fastapi[standard]>=0.123.0",
     "pre-commit>=4.4.0",
     "pydantic-settings>=2.12.0",
+    "transformers>=4.57.3",
+]
+
+[project.optional-dependencies]
+cpu = [
     "torch==2.9.0",
     "torchvision==0.24.0",
-    "transformers>=4.57.3",
+]
+cu128 = [
+    "torch==2.9.0",
+    "torchvision==0.24.0",
 ]
 
 [dependency-groups]
@@ -22,9 +30,30 @@ dev = [
 
 # Lint設定はルートのpyproject.tomlで統一管理
 
+[tool.uv]
+conflicts = [
+    [
+        { extra = "cpu" },
+        { extra = "cu128" },
+    ],
+]
+
 [tool.uv.sources]
-torch = { index = "pytorch-cu128" }
+torch = [
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu128", extra = "cu128" },
+]
+torchvision = [
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu128", extra = "cu128" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [[tool.uv.index]]
 name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
+explicit = true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,18 @@ set -e
 echo "=== AnotherMe Monorepo Setup ==="
 echo ""
 
+# --ci フラグで CPU 版 PyTorch を使用（GPU なし環境向け）
+TORCH_EXTRA="cu128"
+TTS_TORCH_EXTRA="cu124"
+if [ "$1" = "--ci" ]; then
+    TORCH_EXTRA="cpu"
+    TTS_TORCH_EXTRA="cpu"
+    echo "Mode: CI (CPU-only PyTorch)"
+else
+    echo "Mode: Local (GPU PyTorch)"
+fi
+echo ""
+
 # Check dependencies
 command -v node >/dev/null 2>&1 || { echo "Error: Node.js is required"; exit 1; }
 command -v uv >/dev/null 2>&1 || { echo "Error: uv is required. Install: curl -LsSf https://astral.sh/uv/install.sh | sh"; exit 1; }
@@ -17,14 +29,14 @@ echo ""
 echo "2. Setting up Chat Server..."
 cd chat-server
 uv python install
-uv sync --group dev
+uv sync --extra "$TORCH_EXTRA" --group dev
 cd ..
 
 echo ""
 echo "3. Setting up TTS Server..."
 cd tts-server
 uv python install
-uv sync --group dev
+uv sync --extra "$TTS_TORCH_EXTRA" --group dev
 cd ..
 
 echo ""
@@ -33,6 +45,10 @@ command -v pre-commit >/dev/null 2>&1 && pre-commit install || echo "pre-commit 
 
 echo ""
 echo "✓ Setup complete!"
+echo ""
+echo "Usage:"
+echo "  Local (GPU):  ./scripts/setup.sh"
+echo "  CI (CPU):     ./scripts/setup.sh --ci"
 echo ""
 echo "Next steps:"
 echo "  - Frontend:    cd frontend && npm run dev"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -3,17 +3,23 @@ set -e
 
 echo "=== Running All Tests ==="
 
+# --ci フラグで CPU 版 PyTorch を使用
+UV_EXTRA=""
+if [ "$1" = "--ci" ]; then
+    UV_EXTRA="--extra cpu"
+fi
+
 echo ""
 echo "1. Testing TTS Server..."
 cd tts-server
-uv run pytest tests/ -v
+uv run $UV_EXTRA pytest tests/ -v
 cd ..
 
 # Add other test commands as they become available
 # echo ""
 # echo "2. Testing Chat Server..."
 # cd chat-server
-# uv run pytest tests/ -v
+# uv run $UV_EXTRA pytest tests/ -v
 # cd ..
 
 echo ""

--- a/tts-server/pyproject.toml
+++ b/tts-server/pyproject.toml
@@ -9,11 +9,32 @@ dependencies = [
     "fastapi==0.115.6",
     "pydantic==2.7.0",
     "uvicorn==0.30.0",
-    "torchaudio",
     "soundfile==0.12.1",
-    "torch",
     "pydantic-settings>=2.12.0",
 ]
+
+[project.optional-dependencies]
+cpu = [
+    "torch",
+    "torchaudio",
+]
+cu124 = [
+    "torch",
+    "torchaudio",
+]
+
+[tool.uv]
+conflicts = [
+    [
+        { extra = "cpu" },
+        { extra = "cu124" },
+    ],
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [[tool.uv.index]]
 name = "pytorch-cu124"
@@ -21,8 +42,14 @@ url = "https://download.pytorch.org/whl/cu124"
 explicit = true
 
 [tool.uv.sources]
-torch = { index = "pytorch-cu124" }
-torchaudio = { index = "pytorch-cu124" }
+torch = [
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu124", extra = "cu124" },
+]
+torchaudio = [
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu124", extra = "cu124" },
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- CIではGPUが利用できないため、uvの`extras` + `conflicts`パターンを使ってCPU版とCUDA版のPyTorchを切り替えられるようにした
- chat-server: `cpu` / `cu128` extras、tts-server: `cpu` / `cu124` extras を追加
- CIワークフローとsetup.shを `--extra cpu` / `--ci` フラグ対応に更新

## 使い方
```bash
# ローカル開発（GPU）
uv sync --extra cu128 --group dev   # chat-server
uv sync --extra cu124 --group dev   # tts-server

# CI / GPUなし環境
uv sync --extra cpu --group dev

# スクリプト経由
./scripts/setup.sh          # GPU版
./scripts/setup.sh --ci     # CPU版
```

## Test plan
- [ ] CI上で `uv sync --extra cpu --group dev` が正常にインストールされることを確認
- [ ] tts-serverのテストがCPU版torchで通ることを確認
- [ ] ローカルGPU環境で `--extra cu128` / `--extra cu124` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)