### PR TITLE
ci: カバレッジバッジをSmokeshow連携のcoverage-badgeに移行

### DIFF
--- a/.github/workflows/smokeshow.yml
+++ b/.github/workflows/smokeshow.yml
@@ -21,11 +21,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - run: smokeshow upload coverage-html
+      - name: Upload to Smokeshow
+        run: smokeshow upload coverage-html
         env:
-          SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Coverage {coverage-percentage}
+          SMOKESHOW_GITHUB_STATUS_DESCRIPTION: coverage tts-server {coverage-percentage}
           SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 50
-          SMOKESHOW_GITHUB_CONTEXT: coverage
+          SMOKESHOW_GITHUB_CONTEXT: tts-server
           SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           SMOKESHOW_AUTH_KEY: ${{ secrets.SMOKESHOW_AUTH_KEY }}

--- a/.github/workflows/test-tts-server.yml
+++ b/.github/workflows/test-tts-server.yml
@@ -57,24 +57,3 @@ jobs:
         working-directory: tts-server
         run: uv run --extra cpu coverage report
 
-      - name: Extract coverage percentage
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
-        id: coverage
-        working-directory: tts-server
-        run: |
-          COVERAGE=$(uv run --extra cpu coverage report --format=total)
-          echo "total=${COVERAGE}" >> "$GITHUB_OUTPUT"
-          echo "Coverage: ${COVERAGE}%"
-
-      - name: Update coverage badge
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
-        uses: schneegans/dynamic-badges-action@v1.7.0
-        with:
-          auth: ${{ secrets.GIST_TOKEN }}
-          gistID: ac2cfc2237210a437cb17a73d5d4c2a3
-          filename: tts-server-coverage.json
-          label: "coverage: tts-server"
-          message: "${{ steps.coverage.outputs.total }}%"
-          valColorRange: ${{ steps.coverage.outputs.total }}
-          minColorRange: 0
-          maxColorRange: 100

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnotherMe - AI Avatar Platform
 
-[![TTS Server Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Rx-K8/ac2cfc2237210a437cb17a73d5d4c2a3/raw/tts-server-coverage.json)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-tts-server.yml)
+[![TTS Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=tts-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=tts-server)
 
 A monorepo containing the full AnotherMe platform: Frontend, Chat Server, and TTS Server.
 


### PR DESCRIPTION
## Summary
- Gist + shields.io ベースのカバレッジバッジを `coverage-badge.samuelcolvin.workers.dev` に移行
- README のバッジクリックで Smokeshow の HTML カバレッジレポートに直接遷移可能に
- `?match=tts-server` パラメータにより、将来 chat-server 等を追加する際も個別バッジ対応可能

## Changes
- **smokeshow.yml**: `SMOKESHOW_GITHUB_STATUS_DESCRIPTION` と `SMOKESHOW_GITHUB_CONTEXT` を tts-server 固有に変更
- **test-tts-server.yml**: 不要になった `Extract coverage percentage` / `Update coverage badge` (Gist更新) ステップを削除
- **README.md**: バッジ URL を coverage-badge + redirect 形式に変更

## How it works
1. `Test TTS Server` ワークフローがカバレッジ HTML アーティファクトを生成
2. `Coverage Report` ワークフロー (Smokeshow) がアーティファクトをアップロードし、コミットステータスに `coverage tts-server XX.XX%` を設定
3. `coverage-badge.samuelcolvin.workers.dev` がコミットステータスの description から `?match=tts-server` でフィルタしてバッジ SVG を生成
4. `/redirect/` エンドポイントが該当ステータスの `target_url` (Smokeshow レポート) にリダイレクト

## Test plan
- [ ] develop へマージ後、tts-server のテストが走ることを確認
- [ ] Smokeshow のコミットステータスに `smokeshow / tts-server` コンテキストが作成されることを確認
- [ ] README のバッジが正しく表示されることを確認
- [ ] バッジクリックで Smokeshow カバレッジレポートにリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)