### PR TITLE
docs: カバレッジバッジにサーバー名ラベルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # AnotherMe - AI Avatar Platform
 
-[![Chat Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=chat-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=chat-server)
-[![TTS Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=tts-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=tts-server)
+| Chat Server | TTS Server |
+|:---:|:---:|
+| [![Chat Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=chat-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=chat-server) | [![TTS Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=tts-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=tts-server) |
 
 A monorepo containing the full AnotherMe platform: Frontend, Chat Server, and TTS Server.
 


### PR DESCRIPTION
## Summary
- カバレッジバッジにテーブルレイアウトで Chat Server / TTS Server のラベルを追加
- バッジ単体では「coverage XX%」としか表示されず、どのサーバーか区別がつかなかったため

## Test plan
- [ ] README のバッジ表示でサーバー名が見分けられることを確認