### PR TITLE
docs: READMEにテストバッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # AnotherMe - AI Avatar Platform
 
-| Chat Server | TTS Server |
-|:---:|:---:|
-| [![Chat Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=chat-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=chat-server) | [![TTS Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=tts-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=tts-server) |
+| | Chat Server | TTS Server |
+|:---:|:---:|:---:|
+| **Test** | [![Test Chat Server](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-chat-server.yml/badge.svg)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-chat-server.yml) | [![Test TTS Server](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-tts-server.yml/badge.svg)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-tts-server.yml) |
+| **Coverage** | [![Chat Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=chat-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=chat-server) | [![TTS Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=tts-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=tts-server) |
 
 A monorepo containing the full AnotherMe platform: Frontend, Chat Server, and TTS Server.
 


### PR DESCRIPTION
## Summary
- READMEのバッジテーブルにTest Chat Server / Test TTS ServerのGitHub Actionsワークフローバッジを追加
- 既存のカバレッジバッジと合わせてテーブル形式で表示（Test行 + Coverage行）

## Test plan
- [ ] READMEのバッジが正しく表示されることを確認
- [ ] バッジリンクがGitHub Actionsワークフローページに遷移することを確認