### PR TITLE
fix: tts-server mypyのunused-ignoreエラーを修正

### DIFF
--- a/tts-server/app/tts/qwen3.py
+++ b/tts-server/app/tts/qwen3.py
@@ -8,7 +8,7 @@ import io
 import os
 import tempfile
 
-import soundfile as sf  # type: ignore[import-untyped]
+import soundfile as sf
 import torch
 from qwen_tts import Qwen3TTSModel
 


### PR DESCRIPTION
## Summary
- `tts-server/app/tts/qwen3.py` の不要な `type: ignore[import-untyped]` コメントを削除

## 原因
ルート `pyproject.toml` のmypy overridesに `soundfile` が追加されたため、個別の `type: ignore` が不要になり `unused-ignore` エラーが発生

## Test plan
- [ ] Lint TTS Server ワークフローがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)