### PR TITLE
docs: READMEにlipsync-serverのバッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # AnotherMe - AI Avatar Platform
 
-| | Chat Server | TTS Server |
-|:---:|:---:|:---:|
-| **Test** | [![Test Chat Server](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-chat-server.yml/badge.svg)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-chat-server.yml) | [![Test TTS Server](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-tts-server.yml/badge.svg)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-tts-server.yml) |
-| **Coverage** | [![Chat Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=chat-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=chat-server) | [![TTS Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=tts-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=tts-server) |
+| | Chat Server | TTS Server | Lipsync Server |
+|:---:|:---:|:---:|:---:|
+| **Test** | [![Test Chat Server](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-chat-server.yml/badge.svg)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-chat-server.yml) | [![Test TTS Server](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-tts-server.yml/badge.svg)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-tts-server.yml) | [![Test Lipsync Server](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-lipsync-server.yml/badge.svg)](https://github.com/Rx-K8/AnotherMe/actions/workflows/test-lipsync-server.yml) |
+| **Coverage** | [![Chat Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=chat-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=chat-server) | [![TTS Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=tts-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=tts-server) | [![Lipsync Server Coverage](https://coverage-badge.samuelcolvin.workers.dev/Rx-K8/AnotherMe.svg?match=lipsync-server)](https://coverage-badge.samuelcolvin.workers.dev/redirect/Rx-K8/AnotherMe?match=lipsync-server) |
 
 A monorepo containing the full AnotherMe platform: Frontend, Chat Server, and TTS Server.
 


### PR DESCRIPTION
## Summary
- READMEのバッジテーブルにLipsync Server列を追加（Test + Coverage）

## Test plan
- [ ] READMEのマークダウンテーブルが正しくレンダリングされること
- [ ] バッジリンクが正しいワークフロー・カバレッジURLを指していること