### PR TITLE
feat: lipsync-serverバリデーター（audio/media）追加

### DIFF
--- a/lipsync-server/app/validators/__init__.py
+++ b/lipsync-server/app/validators/__init__.py
@@ -1,0 +1,19 @@
+from app.validators.audio import (
+    ALLOWED_AUDIO_EXTENSIONS,
+    MAX_AUDIO_FILE_SIZE,
+    validate_audio_file,
+)
+from app.validators.media import (
+    ALLOWED_MEDIA_EXTENSIONS,
+    MAX_MEDIA_FILE_SIZE,
+    validate_media_file,
+)
+
+__all__ = [
+    "ALLOWED_AUDIO_EXTENSIONS",
+    "ALLOWED_MEDIA_EXTENSIONS",
+    "MAX_AUDIO_FILE_SIZE",
+    "MAX_MEDIA_FILE_SIZE",
+    "validate_audio_file",
+    "validate_media_file",
+]

--- a/lipsync-server/app/validators/audio.py
+++ b/lipsync-server/app/validators/audio.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile
+
+ALLOWED_AUDIO_EXTENSIONS = {".wav", ".mp3"}
+MAX_AUDIO_FILE_SIZE = 10 * 1024 * 1024
+
+
+async def validate_audio_file(audio_file: UploadFile) -> tuple[bytes, str]:
+    filename = audio_file.filename or ""
+    ext = Path(filename).suffix.lower()
+    if ext not in ALLOWED_AUDIO_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Unsupported audio file type.")
+
+    content = await audio_file.read()
+    if len(content) > MAX_AUDIO_FILE_SIZE:
+        raise HTTPException(
+            status_code=400, detail="Audio file size exceeds the maximum limit."
+        )
+    return content, ext

--- a/lipsync-server/app/validators/media.py
+++ b/lipsync-server/app/validators/media.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile, status
+
+ALLOWED_MEDIA_EXTENSIONS = {".mp4", ".mov", ".jpg", ".png"}
+MAX_MEDIA_FILE_SIZE = 50 * 1024 * 1024  # 50MB
+
+
+async def validate_media_file(media_file: UploadFile) -> tuple[bytes, str]:
+    """メディアファイルを検証し、内容と拡張子を返す.
+
+    Args:
+        media_file: アップロードされた動画/画像ファイル
+
+    Returns:
+        tuple[bytes, str]: (ファイル内容, 拡張子)
+
+    Raises:
+        HTTPException: ファイル形式が不正、サイズ超過、または空ファイルの場合
+    """
+    filename = media_file.filename or ""
+    ext = Path(filename).suffix.lower()
+
+    if ext not in ALLOWED_MEDIA_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Supported formats: {', '.join(sorted(ALLOWED_MEDIA_EXTENSIONS))}"
+            ),
+        )
+
+    content = await media_file.read()
+
+    if len(content) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File is empty",
+        )
+
+    if len(content) > MAX_MEDIA_FILE_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File size exceeds the limit (50MB)",
+        )
+
+    return content, ext

--- a/lipsync-server/tests/validators/test_audio.py
+++ b/lipsync-server/tests/validators/test_audio.py
@@ -1,0 +1,46 @@
+from io import BytesIO
+
+import pytest
+from app.validators.audio import validate_audio_file
+from fastapi import HTTPException, UploadFile
+
+
+class TestValidateAudioFile:
+    async def test_validate_wav_file(self) -> None:
+        content = b"fake wav content"
+        upload_file = UploadFile(filename="test.wav", file=BytesIO(content))
+        result_content, result_type = await validate_audio_file(upload_file)
+        assert result_content == content
+        assert result_type == ".wav"
+
+    async def test_validate_mp3_file(self) -> None:
+        content = b"fake mp3 content"
+        upload_file = UploadFile(filename="song.mp3", file=BytesIO(content))
+        result_content, result_type = await validate_audio_file(upload_file)
+        assert result_content == content
+        assert result_type == ".mp3"
+
+    async def test_reject_unsupported_file_type(self) -> None:
+        upload_file = UploadFile(filename="test.ogg", file=BytesIO(b"content"))
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_audio_file(upload_file)
+        assert exc_info.value.status_code == 400
+
+    async def test_reject_oversized_file(self) -> None:
+        large_content = b"a" * (11 * 1024 * 1024)
+        upload_file = UploadFile(filename="large.wav", file=BytesIO(large_content))
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_audio_file(upload_file)
+        assert exc_info.value.status_code == 400
+
+    async def test_reject_empty_filename(self) -> None:
+        upload_file = UploadFile(filename="", file=BytesIO(b"content"))
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_audio_file(upload_file)
+        assert exc_info.value.status_code == 400
+
+    async def test_accept_exactly_max_size_file(self) -> None:
+        max_size_content = b"a" * (10 * 1024 * 1024)
+        upload_file = UploadFile(filename="maxsize.mp3", file=BytesIO(max_size_content))
+        result_content, _ = await validate_audio_file(upload_file)
+        assert len(result_content) == len(max_size_content)

--- a/lipsync-server/tests/validators/test_media.py
+++ b/lipsync-server/tests/validators/test_media.py
@@ -1,0 +1,97 @@
+"""メディア（動画/画像）ファイルバリデーションのテスト."""
+
+from io import BytesIO
+
+import pytest
+from app.validators.media import (
+    ALLOWED_MEDIA_EXTENSIONS,
+    MAX_MEDIA_FILE_SIZE,
+    validate_media_file,
+)
+from fastapi import HTTPException, UploadFile
+
+
+class TestValidateMediaFile:
+    # --- 正常系 ---
+
+    async def test_valid_mp4_file(self) -> None:
+        content = b"fake mp4 content"
+        upload_file = UploadFile(filename="test.mp4", file=BytesIO(content))
+        result_content, result_ext = await validate_media_file(upload_file)
+        assert result_content == content
+        assert result_ext == ".mp4"
+
+    async def test_valid_mov_file(self) -> None:
+        content = b"fake mov content"
+        upload_file = UploadFile(filename="test.mov", file=BytesIO(content))
+        result_content, result_ext = await validate_media_file(upload_file)
+        assert result_content == content
+        assert result_ext == ".mov"
+
+    async def test_valid_jpg_file(self) -> None:
+        content = b"fake jpg content"
+        upload_file = UploadFile(filename="face.jpg", file=BytesIO(content))
+        result_content, result_ext = await validate_media_file(upload_file)
+        assert result_content == content
+        assert result_ext == ".jpg"
+
+    async def test_valid_png_file(self) -> None:
+        content = b"fake png content"
+        upload_file = UploadFile(filename="face.png", file=BytesIO(content))
+        result_content, result_ext = await validate_media_file(upload_file)
+        assert result_content == content
+        assert result_ext == ".png"
+
+    async def test_valid_uppercase_extension(self) -> None:
+        content = b"fake mp4 content"
+        upload_file = UploadFile(filename="test.MP4", file=BytesIO(content))
+        result_content, result_ext = await validate_media_file(upload_file)
+        assert result_content == content
+        assert result_ext == ".mp4"
+
+    # --- 異常系: 拡張子 ---
+
+    async def test_reject_unsupported_extension(self) -> None:
+        upload_file = UploadFile(filename="test.avi", file=BytesIO(b"content"))
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_media_file(upload_file)
+        assert exc_info.value.status_code == 400
+        for ext in sorted(ALLOWED_MEDIA_EXTENSIONS):
+            assert ext in str(exc_info.value.detail)
+
+    async def test_reject_no_extension(self) -> None:
+        upload_file = UploadFile(filename="testfile", file=BytesIO(b"content"))
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_media_file(upload_file)
+        assert exc_info.value.status_code == 400
+
+    async def test_reject_empty_filename(self) -> None:
+        upload_file = UploadFile(filename="", file=BytesIO(b"content"))
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_media_file(upload_file)
+        assert exc_info.value.status_code == 400
+
+    # --- 異常系: サイズ ---
+
+    async def test_reject_oversized_file(self) -> None:
+        large_content = b"x" * (MAX_MEDIA_FILE_SIZE + 1)
+        upload_file = UploadFile(filename="test.mp4", file=BytesIO(large_content))
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_media_file(upload_file)
+        assert exc_info.value.status_code == 400
+        assert "50MB" in str(exc_info.value.detail)
+
+    async def test_accept_exactly_max_size(self) -> None:
+        content = b"x" * MAX_MEDIA_FILE_SIZE
+        upload_file = UploadFile(filename="test.mp4", file=BytesIO(content))
+        result_content, result_ext = await validate_media_file(upload_file)
+        assert len(result_content) == MAX_MEDIA_FILE_SIZE
+        assert result_ext == ".mp4"
+
+    # --- 異常系: 空ファイル ---
+
+    async def test_reject_empty_file(self) -> None:
+        upload_file = UploadFile(filename="test.mp4", file=BytesIO(b""))
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_media_file(upload_file)
+        assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary
- 音声ファイルバリデーター（WAV/MP3、10MB上限）
- メディアファイルバリデーター（MP4/MOV/JPG/PNG、50MB上限、空ファイルチェック）
- `validators/__init__.py` からのエクスポート設定

## Test plan
- [x] `test_audio.py`: 正常系（WAV/MP3）、異常系（非対応形式、サイズ超過、空ファイル名）、境界値（ちょうど10MB）
- [x] `test_media.py`: 正常系（MP4/MOV/JPG/PNG、大文字拡張子）、異常系（非対応形式、サイズ超過、空ファイル、空ファイル名）、境界値（ちょうど50MB）
- [x] 全17テスト通過、カバレッジ100%
- [x] `mypy --strict` パス
- [x] `ruff check` + `ruff format` パス