### PR TITLE
feat: lipsync-server Service層 + MockProvider + Factory

### DIFF
--- a/lipsync-server/app/lipsync/__init__.py
+++ b/lipsync-server/app/lipsync/__init__.py
@@ -1,0 +1,10 @@
+from app.lipsync.abc import LipsyncProvider, LipsyncResult
+from app.lipsync.factory import create_provider
+from app.lipsync.mock import MockLipsyncProvider
+
+__all__ = [
+    "LipsyncProvider",
+    "LipsyncResult",
+    "MockLipsyncProvider",
+    "create_provider",
+]

--- a/lipsync-server/app/lipsync/factory.py
+++ b/lipsync-server/app/lipsync/factory.py
@@ -1,0 +1,27 @@
+"""リップシンクプロバイダーのファクトリー"""
+
+from app.lipsync.abc import LipsyncProvider
+from app.lipsync.mock import MockLipsyncProvider
+
+
+def create_provider(provider_name: str) -> LipsyncProvider:
+    """プロバイダー名からLipsyncProviderインスタンスを生成する
+
+    Args:
+        provider_name: プロバイダー名 ("mock" など)
+
+    Raises:
+        ValueError: 不明なプロバイダー名の場合
+    """
+    providers: dict[str, type[LipsyncProvider]] = {
+        "mock": MockLipsyncProvider,
+    }
+
+    provider_class = providers.get(provider_name)
+    if provider_class is None:
+        available = ", ".join(sorted(providers.keys()))
+        raise ValueError(
+            f"不明なプロバイダー名: {provider_name!r} (利用可能: {available})"
+        )
+
+    return provider_class()

--- a/lipsync-server/app/lipsync/mock.py
+++ b/lipsync-server/app/lipsync/mock.py
@@ -1,0 +1,28 @@
+"""テスト・開発用のモックリップシンクプロバイダー"""
+
+from app.lipsync.abc import LipsyncProvider, LipsyncResult
+
+# 最小限のダミーMP4バイト列（ftyp box header）
+_DUMMY_MP4 = b"\x00\x00\x00\x1c\x66\x74\x79\x70\x69\x73\x6f\x6d"
+
+_DUMMY_DURATION = 1.0
+
+
+class MockLipsyncProvider(LipsyncProvider):
+    """GPU不要のモックプロバイダー。固定ダミーMP4データを返す。"""
+
+    async def generate(
+        self,
+        audio_path: str,
+        video_path: str,
+        bbox_shift: int = 0,
+        extra_margin: int = 10,
+        parsing_mode: str = "jaw",
+    ) -> LipsyncResult:
+        return LipsyncResult(
+            video_bytes=_DUMMY_MP4,
+            duration_seconds=_DUMMY_DURATION,
+        )
+
+    async def is_ready(self) -> bool:
+        return True

--- a/lipsync-server/app/services/__init__.py
+++ b/lipsync-server/app/services/__init__.py
@@ -1,0 +1,6 @@
+from app.services.lipsync_service import LipsyncService, LipsyncServiceResult
+
+__all__ = [
+    "LipsyncService",
+    "LipsyncServiceResult",
+]

--- a/lipsync-server/app/services/lipsync_service.py
+++ b/lipsync-server/app/services/lipsync_service.py
@@ -1,0 +1,81 @@
+"""リップシンクサービス層"""
+
+import asyncio
+import base64
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+
+from app.lipsync.abc import LipsyncProvider
+
+
+@dataclass(frozen=True)
+class LipsyncServiceResult:
+    """サービス層の処理結果"""
+
+    video_base64: str
+    duration_seconds: float
+    processing_time_ms: int
+
+
+class LipsyncService:
+    """リップシンク生成サービス
+
+    GPU排他制御、一時ファイル管理、base64変換を担当する。
+    """
+
+    def __init__(self, provider: LipsyncProvider) -> None:
+        self._provider = provider
+        self._semaphore = asyncio.Semaphore(1)
+
+    async def generate(
+        self,
+        audio_bytes: bytes,
+        audio_ext: str,
+        video_bytes: bytes,
+        video_ext: str,
+        bbox_shift: int = 0,
+        extra_margin: int = 10,
+        parsing_mode: str = "jaw",
+    ) -> LipsyncServiceResult:
+        audio_path: str | None = None
+        video_path: str | None = None
+
+        async with self._semaphore:
+            try:
+                start = time.monotonic()
+
+                with tempfile.NamedTemporaryFile(
+                    delete=False, suffix=audio_ext, prefix="lipsync_audio_"
+                ) as af:
+                    af.write(audio_bytes)
+                    audio_path = af.name
+
+                with tempfile.NamedTemporaryFile(
+                    delete=False, suffix=video_ext, prefix="lipsync_video_"
+                ) as vf:
+                    vf.write(video_bytes)
+                    video_path = vf.name
+
+                result = await self._provider.generate(
+                    audio_path=audio_path,
+                    video_path=video_path,
+                    bbox_shift=bbox_shift,
+                    extra_margin=extra_margin,
+                    parsing_mode=parsing_mode,
+                )
+
+                elapsed_ms = int((time.monotonic() - start) * 1000)
+                video_base64 = base64.b64encode(result.video_bytes).decode("utf-8")
+
+                return LipsyncServiceResult(
+                    video_base64=video_base64,
+                    duration_seconds=result.duration_seconds,
+                    processing_time_ms=elapsed_ms,
+                )
+            finally:
+                if audio_path is not None:
+                    os.unlink(audio_path)
+                if video_path is not None:
+                    os.unlink(video_path)

--- a/lipsync-server/tests/lipsync/test_factory.py
+++ b/lipsync-server/tests/lipsync/test_factory.py
@@ -1,0 +1,20 @@
+import pytest
+from app.lipsync.factory import create_provider
+from app.lipsync.mock import MockLipsyncProvider
+
+
+class TestCreateProvider:
+    @pytest.mark.unit
+    def test_create_mock_provider(self) -> None:
+        provider = create_provider("mock")
+        assert isinstance(provider, MockLipsyncProvider)
+
+    @pytest.mark.unit
+    def test_unknown_provider_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="unknown"):
+            create_provider("unknown")
+
+    @pytest.mark.unit
+    def test_empty_name_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            create_provider("")

--- a/lipsync-server/tests/lipsync/test_mock.py
+++ b/lipsync-server/tests/lipsync/test_mock.py
@@ -1,0 +1,52 @@
+import pytest
+from app.lipsync.abc import LipsyncResult
+from app.lipsync.mock import MockLipsyncProvider
+
+
+class TestMockLipsyncProvider:
+    @pytest.fixture
+    def provider(self) -> MockLipsyncProvider:
+        return MockLipsyncProvider()
+
+    @pytest.mark.unit
+    async def test_generate_returns_lipsync_result(
+        self, provider: MockLipsyncProvider
+    ) -> None:
+        result = await provider.generate(
+            audio_path="/tmp/test.wav",
+            video_path="/tmp/test.mp4",
+        )
+        assert isinstance(result, LipsyncResult)
+        assert isinstance(result.video_bytes, bytes)
+        assert len(result.video_bytes) > 0
+        assert result.duration_seconds > 0
+
+    @pytest.mark.unit
+    async def test_is_ready_returns_true(self, provider: MockLipsyncProvider) -> None:
+        assert await provider.is_ready() is True
+
+    @pytest.mark.unit
+    async def test_generate_accepts_all_parameters(
+        self, provider: MockLipsyncProvider
+    ) -> None:
+        result = await provider.generate(
+            audio_path="/tmp/test.wav",
+            video_path="/tmp/test.mp4",
+            bbox_shift=5,
+            extra_margin=20,
+            parsing_mode="face",
+        )
+        assert isinstance(result, LipsyncResult)
+
+    @pytest.mark.unit
+    async def test_generate_returns_consistent_results(
+        self, provider: MockLipsyncProvider
+    ) -> None:
+        result1 = await provider.generate(
+            audio_path="/tmp/a.wav", video_path="/tmp/a.mp4"
+        )
+        result2 = await provider.generate(
+            audio_path="/tmp/b.wav", video_path="/tmp/b.mp4"
+        )
+        assert result1.video_bytes == result2.video_bytes
+        assert result1.duration_seconds == result2.duration_seconds

--- a/lipsync-server/tests/services/test_lipsync_service.py
+++ b/lipsync-server/tests/services/test_lipsync_service.py
@@ -1,0 +1,174 @@
+import asyncio
+import base64
+
+import pytest
+from app.lipsync.mock import _DUMMY_MP4, MockLipsyncProvider
+from app.services.lipsync_service import LipsyncService, LipsyncServiceResult
+
+
+class TestLipsyncService:
+    @pytest.fixture
+    def service(self) -> LipsyncService:
+        return LipsyncService(provider=MockLipsyncProvider())
+
+    @pytest.mark.unit
+    async def test_generate_returns_service_result(
+        self, service: LipsyncService
+    ) -> None:
+        result = await service.generate(
+            audio_bytes=b"fake audio",
+            audio_ext=".wav",
+            video_bytes=b"fake video",
+            video_ext=".mp4",
+        )
+        assert isinstance(result, LipsyncServiceResult)
+
+    @pytest.mark.unit
+    async def test_generate_returns_valid_base64(self, service: LipsyncService) -> None:
+        result = await service.generate(
+            audio_bytes=b"fake audio",
+            audio_ext=".wav",
+            video_bytes=b"fake video",
+            video_ext=".mp4",
+        )
+        decoded = base64.b64decode(result.video_base64)
+        assert decoded == _DUMMY_MP4
+
+    @pytest.mark.unit
+    async def test_generate_reports_positive_processing_time(
+        self, service: LipsyncService
+    ) -> None:
+        result = await service.generate(
+            audio_bytes=b"fake audio",
+            audio_ext=".wav",
+            video_bytes=b"fake video",
+            video_ext=".mp4",
+        )
+        assert result.processing_time_ms >= 0
+
+    @pytest.mark.unit
+    async def test_generate_reports_duration(self, service: LipsyncService) -> None:
+        result = await service.generate(
+            audio_bytes=b"fake audio",
+            audio_ext=".wav",
+            video_bytes=b"fake video",
+            video_ext=".mp4",
+        )
+        assert result.duration_seconds > 0
+
+    @pytest.mark.unit
+    async def test_generate_passes_parameters_to_provider(self) -> None:
+        """パラメータがproviderに正しく渡されることを確認"""
+        captured: dict[str, object] = {}
+
+        class CapturingProvider(MockLipsyncProvider):
+            async def generate(
+                self,
+                audio_path: str,
+                video_path: str,
+                bbox_shift: int = 0,
+                extra_margin: int = 10,
+                parsing_mode: str = "jaw",
+            ) -> "LipsyncServiceResult":  # type: ignore[override]
+                captured["bbox_shift"] = bbox_shift
+                captured["extra_margin"] = extra_margin
+                captured["parsing_mode"] = parsing_mode
+                return await super().generate(
+                    audio_path, video_path, bbox_shift, extra_margin, parsing_mode
+                )
+
+        service = LipsyncService(provider=CapturingProvider())
+        await service.generate(
+            audio_bytes=b"audio",
+            audio_ext=".wav",
+            video_bytes=b"video",
+            video_ext=".mp4",
+            bbox_shift=5,
+            extra_margin=20,
+            parsing_mode="face",
+        )
+        assert captured["bbox_shift"] == 5
+        assert captured["extra_margin"] == 20
+        assert captured["parsing_mode"] == "face"
+
+    @pytest.mark.unit
+    async def test_semaphore_limits_concurrency(self, service: LipsyncService) -> None:
+        """セマフォにより同時実行が1に制限されることを確認"""
+        running = 0
+        max_running = 0
+
+        original_generate = service._provider.generate
+
+        async def slow_generate(**kwargs: object) -> object:
+            nonlocal running, max_running
+            running += 1
+            max_running = max(max_running, running)
+            await asyncio.sleep(0.05)
+            result = await original_generate(
+                audio_path=str(kwargs.get("audio_path", "/tmp/a.wav")),
+                video_path=str(kwargs.get("video_path", "/tmp/a.mp4")),
+            )
+            running -= 1
+            return result
+
+        service._provider.generate = slow_generate  # type: ignore[assignment]
+
+        tasks = [
+            service.generate(
+                audio_bytes=b"audio",
+                audio_ext=".wav",
+                video_bytes=b"video",
+                video_ext=".mp4",
+            )
+            for _ in range(3)
+        ]
+        await asyncio.gather(*tasks)
+        assert max_running == 1
+
+    @pytest.mark.unit
+    async def test_tempfiles_cleaned_up_after_generate(
+        self, service: LipsyncService
+    ) -> None:
+        """一時ファイルが生成後に削除されることを確認"""
+        import glob
+        import tempfile
+
+        temp_dir = tempfile.gettempdir()
+        # 生成前のtmpファイル数を記録
+        before = set(glob.glob(f"{temp_dir}/lipsync_*"))
+
+        await service.generate(
+            audio_bytes=b"fake audio",
+            audio_ext=".wav",
+            video_bytes=b"fake video",
+            video_ext=".mp4",
+        )
+
+        after = set(glob.glob(f"{temp_dir}/lipsync_*"))
+        # 新しい一時ファイルが残っていないこと
+        assert after - before == set()
+
+    @pytest.mark.unit
+    async def test_tempfiles_cleaned_up_on_provider_error(self) -> None:
+        """プロバイダーエラー時も一時ファイルが削除されること"""
+        import glob
+        import tempfile
+
+        class FailingProvider(MockLipsyncProvider):
+            async def generate(self, *args: object, **kwargs: object) -> object:  # type: ignore[override]
+                raise RuntimeError("GPU error")
+
+        service = LipsyncService(provider=FailingProvider())
+        temp_dir = tempfile.gettempdir()
+        before = set(glob.glob(f"{temp_dir}/lipsync_*"))
+
+        with pytest.raises(RuntimeError, match="GPU error"):
+            await service.generate(
+                audio_bytes=b"audio",
+                audio_ext=".wav",
+                video_bytes=b"video",
+                video_ext=".mp4",
+            )
+
+        after = set(glob.glob(f"{temp_dir}/lipsync_*"))
+        assert after - before == set()


### PR DESCRIPTION
## Summary

- **MockLipsyncProvider**: `LipsyncProvider` ABCを継承したGPU不要のテスト用プロバイダー。固定ダミーMP4バイト列を返す
- **create_provider**: プロバイダー名（"mock"等）からインスタンスを生成するファクトリー関数。将来の MuseTalkProvider 追加に対応
- **LipsyncService**: GPU排他制御（`asyncio.Semaphore(1)`）、一時ファイル管理（`tempfile` + `finally`クリーンアップ）、base64変換、処理時間計測を担当するサービス層

## New Files

| ファイル | 内容 |
|---------|------|
| `app/lipsync/mock.py` | MockLipsyncProvider |
| `app/lipsync/factory.py` | create_provider ファクトリー |
| `app/services/lipsync_service.py` | LipsyncService + LipsyncServiceResult |
| `app/lipsync/__init__.py` | エクスポート更新 |
| `app/services/__init__.py` | エクスポート更新 |
| `tests/lipsync/test_mock.py` | MockProvider テスト (4件) |
| `tests/lipsync/test_factory.py` | Factory テスト (3件) |
| `tests/services/test_lipsync_service.py` | Service テスト (8件) |

## Test plan

- [x] `uv run pytest tests/ -v -m "not gpu"` — 32テスト全合格
- [x] `uv run mypy --strict app` — no issues found
- [x] `uv run ruff check app tests` — all checks passed
- [x] `uv run ruff format app tests --check` — all formatted
- [x] カバレッジ 81% (新規コード100%、全体80%超)
- [x] pre-commit hooks 全パス