### PR TITLE
feat: lipsync-server APIルーター + main.py

### DIFF
--- a/lipsync-server/app/api/main.py
+++ b/lipsync-server/app/api/main.py
@@ -1,0 +1,10 @@
+"""APIルーター集約"""
+
+from fastapi import APIRouter
+
+from app.api.routes import health, lipsync
+
+api_router = APIRouter(prefix="/api")
+
+api_router.include_router(health.router)
+api_router.include_router(lipsync.router)

--- a/lipsync-server/app/api/routes/health.py
+++ b/lipsync-server/app/api/routes/health.py
@@ -1,0 +1,10 @@
+"""ヘルスチェックAPIルート"""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/health", tags=["Health"])
+
+
+@router.get("/")
+async def health_check() -> dict[str, str]:
+    return {"status": "ok"}

--- a/lipsync-server/app/api/routes/lipsync.py
+++ b/lipsync-server/app/api/routes/lipsync.py
@@ -1,0 +1,78 @@
+"""リップシンク生成APIルート"""
+
+import logging
+
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile, status
+
+from app.api.schema import LipsyncErrorResponse, LipsyncResponse, ParsingMode
+from app.services.lipsync_service import LipsyncService
+from app.validators.audio import validate_audio_file
+from app.validators.media import validate_media_file
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/lipsync", tags=["Lipsync"])
+
+
+def _get_lipsync_service(request: Request) -> LipsyncService:
+    return request.app.state.lipsync_service  # type: ignore[no-any-return]
+
+
+@router.post(
+    "/generate",
+    response_model=LipsyncResponse,
+    responses={
+        400: {"model": LipsyncErrorResponse, "description": "不正なリクエスト"},
+        500: {"model": LipsyncErrorResponse, "description": "内部サーバーエラー"},
+    },
+    summary="リップシンク動画生成",
+    description=(
+        "音声と動画/画像からリップシンク動画を生成します。"
+        "対応形式: WAV/MP3 + MP4/MOV/JPG/PNG"
+    ),
+)
+async def generate_lipsync(
+    request: Request,
+    audio_file: UploadFile = File(..., description="音声ファイル（WAV/MP3形式）"),
+    video_file: UploadFile = File(
+        ..., description="動画/画像ファイル（MP4/MOV/JPG/PNG形式）"
+    ),
+    bbox_shift: int = Form(default=0, description="バウンディングボックスのシフト量"),
+    extra_margin: int = Form(default=10, description="顔領域の追加マージン"),
+    parsing_mode: ParsingMode = Form(
+        default=ParsingMode.JAW, description="顔パースモード"
+    ),
+) -> LipsyncResponse:
+    try:
+        service = _get_lipsync_service(request)
+        audio_bytes, audio_ext = await validate_audio_file(audio_file)
+        video_bytes, video_ext = await validate_media_file(video_file)
+
+        result = await service.generate(
+            audio_bytes=audio_bytes,
+            audio_ext=audio_ext,
+            video_bytes=video_bytes,
+            video_ext=video_ext,
+            bbox_shift=bbox_shift,
+            extra_margin=extra_margin,
+            parsing_mode=parsing_mode.value,
+        )
+
+        return LipsyncResponse(
+            video_data=result.video_base64,
+            duration_seconds=result.duration_seconds,
+            processing_time_ms=result.processing_time_ms,
+        )
+    except HTTPException:
+        raise
+    except ValueError as e:
+        logger.error("不正なリクエストパラメータ: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except Exception as e:
+        logger.exception("リップシンク生成中にエラーが発生しました: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"リップシンク生成中にエラーが発生しました: {e!s}",
+        )

--- a/lipsync-server/app/core/config.py
+++ b/lipsync-server/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     gpu_device: str = "cuda:2"
     max_audio_size_mb: int = 10
     max_video_size_mb: int = 50
+    provider_name: str = "mock"
 
 
 settings = Settings()

--- a/lipsync-server/app/main.py
+++ b/lipsync-server/app/main.py
@@ -1,0 +1,58 @@
+"""FastAPIアプリケーションのエントリーポイント"""
+
+import logging
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.api.main import api_router
+from app.core.config import settings
+from app.lipsync.factory import create_provider
+from app.services.lipsync_service import LipsyncService
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """アプリケーション起動時の初期化処理"""
+    logger.info("リップシンクプロバイダーの初期化を開始します...")
+    provider = create_provider(settings.provider_name)
+    app.state.lipsync_service = LipsyncService(provider=provider)
+    logger.info(
+        "リップシンクプロバイダー(%s)の初期化が完了しました",
+        settings.provider_name,
+    )
+
+    yield
+
+    logger.info("シャットダウン処理が完了しました")
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="AnotherMe Lipsync Server",
+        lifespan=lifespan,
+    )
+    app.include_router(api_router)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    return app
+
+
+app = create_app()

--- a/lipsync-server/tests/api/routes/test_health.py
+++ b/lipsync-server/tests/api/routes/test_health.py
@@ -1,0 +1,14 @@
+"""ヘルスチェックAPIのテスト"""
+
+from httpx import AsyncClient
+
+
+class TestHealthCheck:
+    async def test_health_check_returns_ok(self, client: AsyncClient) -> None:
+        response = await client.get("/api/health/")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    async def test_health_check_content_type(self, client: AsyncClient) -> None:
+        response = await client.get("/api/health/")
+        assert response.headers["content-type"] == "application/json"

--- a/lipsync-server/tests/api/routes/test_lipsync.py
+++ b/lipsync-server/tests/api/routes/test_lipsync.py
@@ -1,0 +1,232 @@
+"""リップシンク生成APIのテスト"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from httpx import AsyncClient
+
+
+class TestGenerateLipsync:
+    """POST /api/lipsync/generate のテスト"""
+
+    async def test_generate_success_with_wav_and_mp4(
+        self,
+        client: AsyncClient,
+        mock_lipsync_service: MagicMock,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "video_data" in data
+        assert "duration_seconds" in data
+        assert "processing_time_ms" in data
+        mock_lipsync_service.generate.assert_called_once()
+
+    async def test_generate_success_with_mp3_and_jpg(
+        self,
+        client: AsyncClient,
+        mock_lipsync_service: MagicMock,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.mp3", sample_wav_content, "audio/mpeg"),
+                "video_file": ("test.jpg", sample_mp4_content, "image/jpeg"),
+            },
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_lipsync_service.generate.call_args.kwargs
+        assert call_kwargs["audio_ext"] == ".mp3"
+        assert call_kwargs["video_ext"] == ".jpg"
+
+    async def test_generate_with_custom_parameters(
+        self,
+        client: AsyncClient,
+        mock_lipsync_service: MagicMock,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+            data={
+                "bbox_shift": "5",
+                "extra_margin": "20",
+                "parsing_mode": "face",
+            },
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_lipsync_service.generate.call_args.kwargs
+        assert call_kwargs["bbox_shift"] == 5
+        assert call_kwargs["extra_margin"] == 20
+        assert call_kwargs["parsing_mode"] == "face"
+
+    async def test_generate_uses_default_parameters(
+        self,
+        client: AsyncClient,
+        mock_lipsync_service: MagicMock,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_lipsync_service.generate.call_args.kwargs
+        assert call_kwargs["bbox_shift"] == 0
+        assert call_kwargs["extra_margin"] == 10
+        assert call_kwargs["parsing_mode"] == "jaw"
+
+    async def test_generate_rejects_unsupported_audio_format(
+        self,
+        client: AsyncClient,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.ogg", sample_wav_content, "audio/ogg"),
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+        )
+        assert response.status_code == 400
+
+    async def test_generate_rejects_unsupported_video_format(
+        self,
+        client: AsyncClient,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+                "video_file": ("test.avi", sample_mp4_content, "video/avi"),
+            },
+        )
+        assert response.status_code == 400
+
+    async def test_generate_rejects_oversized_audio(
+        self,
+        client: AsyncClient,
+        sample_mp4_content: bytes,
+    ) -> None:
+        large_audio = b"x" * (10 * 1024 * 1024 + 1)
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", large_audio, "audio/wav"),
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+        )
+        assert response.status_code == 400
+
+    async def test_generate_rejects_empty_video_file(
+        self,
+        client: AsyncClient,
+        sample_wav_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+                "video_file": ("test.mp4", b"", "video/mp4"),
+            },
+        )
+        assert response.status_code == 400
+
+    async def test_generate_missing_audio_file(
+        self,
+        client: AsyncClient,
+        sample_mp4_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+        )
+        assert response.status_code == 422
+
+    async def test_generate_missing_video_file(
+        self,
+        client: AsyncClient,
+        sample_wav_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+            },
+        )
+        assert response.status_code == 422
+
+    async def test_generate_invalid_parsing_mode(
+        self,
+        client: AsyncClient,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+            data={"parsing_mode": "invalid"},
+        )
+        assert response.status_code == 422
+
+    async def test_generate_value_error_returns_400(
+        self,
+        client: AsyncClient,
+        mock_lipsync_service: MagicMock,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        mock_lipsync_service.generate = AsyncMock(
+            side_effect=ValueError("無効なパラメータ")
+        )
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+        )
+        assert response.status_code == 400
+
+    async def test_generate_runtime_error_returns_500(
+        self,
+        client: AsyncClient,
+        mock_lipsync_service: MagicMock,
+        sample_wav_content: bytes,
+        sample_mp4_content: bytes,
+    ) -> None:
+        mock_lipsync_service.generate = AsyncMock(side_effect=RuntimeError("GPU error"))
+        response = await client.post(
+            "/api/lipsync/generate",
+            files={
+                "audio_file": ("test.wav", sample_wav_content, "audio/wav"),
+                "video_file": ("test.mp4", sample_mp4_content, "video/mp4"),
+            },
+        )
+        assert response.status_code == 500
+        assert "エラーが発生しました" in response.json()["detail"]

--- a/lipsync-server/tests/conftest.py
+++ b/lipsync-server/tests/conftest.py
@@ -1,0 +1,67 @@
+"""共有テストフィクスチャ"""
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from app.api.main import api_router
+from app.services.lipsync_service import LipsyncServiceResult
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def mock_lipsync_service() -> MagicMock:
+    """LipsyncServiceのモック"""
+    mock = MagicMock()
+    mock.generate = AsyncMock(
+        return_value=LipsyncServiceResult(
+            video_base64="dGVzdA==",
+            duration_seconds=1.0,
+            processing_time_ms=100,
+        )
+    )
+    return mock
+
+
+@pytest.fixture
+def app(mock_lipsync_service: MagicMock) -> FastAPI:
+    """テスト用FastAPIアプリケーション"""
+    test_app = FastAPI(title="Test App")
+    test_app.include_router(api_router)
+    test_app.state.lipsync_service = mock_lipsync_service
+    return test_app
+
+
+@pytest.fixture
+async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+    """非同期HTTPクライアント"""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+def sample_wav_content() -> bytes:
+    """テスト用WAVファイル（最小限の有効なヘッダー）"""
+    return (
+        b"RIFF"
+        b"\x24\x00\x00\x00"
+        b"WAVE"
+        b"fmt "
+        b"\x10\x00\x00\x00"
+        b"\x01\x00"
+        b"\x01\x00"
+        b"\x44\xac\x00\x00"
+        b"\x88\x58\x01\x00"
+        b"\x02\x00"
+        b"\x10\x00"
+        b"data"
+        b"\x00\x00\x00\x00"
+    )
+
+
+@pytest.fixture
+def sample_mp4_content() -> bytes:
+    """テスト用MP4ファイル（最小限のftypヘッダー）"""
+    return b"\x00\x00\x00\x1c\x66\x74\x79\x70\x69\x73\x6f\x6d"

--- a/lipsync-server/tests/core/test_config.py
+++ b/lipsync-server/tests/core/test_config.py
@@ -1,0 +1,11 @@
+"""設定クラスのテスト"""
+
+import pytest
+from app.core.config import Settings
+
+
+class TestSettings:
+    @pytest.mark.unit
+    def test_default_provider_name(self) -> None:
+        s = Settings()
+        assert s.provider_name == "mock"


### PR DESCRIPTION
## Summary

- `GET /api/health` ヘルスチェックエンドポイント追加
- `POST /api/lipsync/generate` multipart/form-dataエンドポイント追加（audio_file, video_file, bbox_shift, extra_margin, parsing_mode）
- `app/api/main.py` APIRouter集約（`/api` prefix）
- `app/main.py` FastAPIアプリ + lifespan（provider初期化）+ CORS
- `app/core/config.py` に `provider_name` 設定追加（デフォルト: `mock`、環境変数 `PROVIDER_NAME` で制御）
- tts-serverの既存パターンに準拠（`_get_lipsync_service(request)` ヘルパー、エラーハンドリング構造）

## Test plan

- [x] `GET /api/health/` → 200 `{"status": "ok"}` 
- [x] `POST /api/lipsync/generate` 正常系（WAV+MP4, MP3+JPG）→ 200
- [x] カスタムパラメータ（bbox_shift, extra_margin, parsing_mode=face）→ 正しく伝播
- [x] デフォルトパラメータ（0, 10, jaw）→ 正しく適用
- [x] 不正音声形式（.ogg）→ 400
- [x] 不正動画形式（.avi）→ 400
- [x] サイズ超過音声（>10MB）→ 400
- [x] 空動画ファイル → 400
- [x] 必須フィールド欠落 → 422
- [x] 不正 parsing_mode → 422
- [x] Service ValueError → 400
- [x] Service RuntimeError → 500
- [x] provider_name デフォルト値 → "mock"
- [x] 全48テストPASS、カバレッジ99%
- [x] ruff check / format PASS
- [x] mypy PASS