### PR TITLE
feat: MuseTalkProvider実装 + GPU推論基盤

### DIFF
--- a/lipsync-server/README.md
+++ b/lipsync-server/README.md
@@ -1,0 +1,150 @@
+# AnotherMe Lipsync Server
+
+MuseTalk を利用したリップシンク動画生成サーバー（FastAPI, Python 3.10, CUDA 11.8）。
+
+## インストール
+
+### uv 環境のセットアップ
+
+```bash
+# uv のインストール（未インストールの場合）
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 開発環境
+cd lipsync-server
+uv sync --group dev
+```
+
+### OpenMMLab のインストール（必須・GPU 環境のみ）
+
+MuseTalk の顔ランドマーク検出に mmpose が必要。
+mmcv / mmdet / mmpose は pip wheel の互換性の問題から `pyproject.toml` に含めておらず、`mim install` で別途インストールする。
+
+```bash
+# setuptools を固定（v82+ は pkg_resources を削除しており mmcv が動作しない）
+uv pip install "setuptools<70"
+
+# OpenMMLab のインストール
+uv pip install openmim
+uv run mim install mmengine mmcv==2.0.1 mmdet==3.1.0 mmpose==1.1.0
+```
+
+> **注意**: `uv sync` や `uv run` を実行すると、lockfile に存在しないパッケージ（mmcv 等）が削除される場合がある。
+> GPU テストの実行時は `.venv/bin/pytest` を直接使用すること（後述）。
+
+### chumpy のインストール（mmpose の依存）
+
+chumpy のビルドには pip モジュールが必要だが、uv 環境には含まれていない場合がある。
+
+```bash
+# pip をブートストラップ
+curl -sS https://bootstrap.pypa.io/get-pip.py | .venv/bin/python
+
+# chumpy をインストール（ビルド分離を無効化）
+.venv/bin/pip install chumpy --no-build-isolation
+```
+
+### MuseTalk サブモジュール
+
+```bash
+# サブモジュールの初期化（リポジトリルートで実行）
+git submodule update --init lipsync-server/submodules/MuseTalk
+```
+
+モデルの重みは別途ダウンロードし、`submodules/MuseTalk/models/` に配置する。
+
+```bash
+cd submodules/MuseTalk
+bash download_weights.sh
+```
+
+## サーバーの起動
+
+```bash
+uv run uvicorn app.main:app --host 0.0.0.0 --port 8002
+```
+
+### デモ UI の有効化
+
+環境変数 `ENABLE_DEMO=true` を設定すると `/demo` にテスト用 UI が表示される。
+
+```bash
+ENABLE_DEMO=true uv run uvicorn app.main:app --host 0.0.0.0 --port 8002
+```
+
+## Docker イメージのビルドと起動
+
+### Docker イメージのビルド
+
+```bash
+docker build -t nvidia-anotherme/lipsync-server:cu118-runtime .
+```
+
+### Docker コンテナの起動
+
+モデルの重みはボリュームマウントで提供する（イメージには含まれない）。
+
+```bash
+docker run --rm -p 8002:8002 --gpus '"device=2"' \
+  -v /path/to/MuseTalk/models:/app/submodules/MuseTalk/models \
+  nvidia-anotherme/lipsync-server:cu118-runtime
+```
+
+## テスト
+
+### 単体テスト + 統合テスト（GPU 不要）
+
+```bash
+uv run pytest -m "not gpu" --cov
+```
+
+### GPU テスト
+
+`uv run` は lockfile にない手動インストールパッケージを削除するため、`.venv/bin/pytest` を直接使用する。
+
+```bash
+.venv/bin/pytest -m gpu -v
+```
+
+## 依存関係のトラブルシューティング
+
+### `ModuleNotFoundError: No module named 'mmpose'`
+
+mmpose は `pyproject.toml` に含まれていない。「OpenMMLab のインストール」の手順を参照。
+
+### `ModuleNotFoundError: No module named 'pkg_resources'`
+
+setuptools v82 以降は `pkg_resources` が削除されている。`setuptools<70` をインストールする。
+
+```bash
+uv pip install "setuptools<70"
+```
+
+### `uv run` 後に mmcv / mmpose が消える
+
+`uv run` は lockfile と環境を同期するため、lockfile に存在しないパッケージを削除する。
+GPU テストは `.venv/bin/pytest` を直接使用すること。
+
+```bash
+# NG: mmcv 等が削除される
+uv run pytest -m gpu
+
+# OK: 手動インストールしたパッケージが維持される
+.venv/bin/pytest -m gpu -v
+```
+
+### `FileNotFoundError: './musetalk/utils/dwpose/...'`
+
+MuseTalk の `preprocessing.py` がモジュールレベルで相対パスを使用しており、CWD が `submodules/MuseTalk/` でないと失敗する。
+`musetalk_provider.py` の `_chdir_musetalk()` コンテキストマネージャーで対処済みだが、
+MuseTalk を直接使う場合は CWD に注意すること。
+
+### chumpy のビルドエラー (`No module named 'pip'`)
+
+chumpy の `setup.py` がビルド時に pip を import する。uv 環境には pip が無いためエラーになる。
+pip をブートストラップしてから `--no-build-isolation` でインストールする。
+
+```bash
+curl -sS https://bootstrap.pypa.io/get-pip.py | .venv/bin/python
+.venv/bin/pip install chumpy --no-build-isolation
+```

--- a/lipsync-server/README.md
+++ b/lipsync-server/README.md
@@ -18,19 +18,15 @@ uv sync --group dev
 ### OpenMMLab のインストール（必須・GPU 環境のみ）
 
 MuseTalk の顔ランドマーク検出に mmpose が必要。
-mmcv / mmdet / mmpose は pip wheel の互換性の問題から `pyproject.toml` に含めておらず、`mim install` で別途インストールする。
+mmcv / mmdet / mmpose は CUDA 固有のビルドが必要で `pyproject.toml` に含めていないため、`mim install` で別途インストールする。
 
 ```bash
-# setuptools を固定（v82+ は pkg_resources を削除しており mmcv が動作しない）
-uv pip install "setuptools<70"
-
-# OpenMMLab のインストール
-uv pip install openmim
-uv run mim install mmengine mmcv==2.0.1 mmdet==3.1.0 mmpose==1.1.0
+# OpenMMLab のインストール（.venv/bin/ を使用）
+.venv/bin/mim install mmengine mmcv==2.0.1 mmdet==3.1.0 mmpose==1.1.0
 ```
 
-> **注意**: `uv sync` や `uv run` を実行すると、lockfile に存在しないパッケージ（mmcv 等）が削除される場合がある。
-> GPU テストの実行時は `.venv/bin/pytest` を直接使用すること（後述）。
+> **重要**: `uv sync` や `uv run` を実行すると、lockfile に存在しないパッケージ（mmcv 等）が自動削除される。
+> サーバー起動・GPU テストには `.venv/bin/` を直接使用すること（後述）。
 
 ### chumpy のインストール（mmpose の依存）
 
@@ -54,14 +50,15 @@ git submodule update --init lipsync-server/submodules/MuseTalk
 モデルの重みは別途ダウンロードし、`submodules/MuseTalk/models/` に配置する。
 
 ```bash
-cd submodules/MuseTalk
 bash download_weights.sh
 ```
 
 ## サーバーの起動
 
+`uv run` は lockfile 同期で mmcv 等を削除するため、`.venv/bin/uvicorn` を直接使用する。
+
 ```bash
-uv run uvicorn app.main:app --host 0.0.0.0 --port 8002
+.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8002
 ```
 
 ### デモ UI の有効化
@@ -69,7 +66,7 @@ uv run uvicorn app.main:app --host 0.0.0.0 --port 8002
 環境変数 `ENABLE_DEMO=true` を設定すると `/demo` にテスト用 UI が表示される。
 
 ```bash
-ENABLE_DEMO=true uv run uvicorn app.main:app --host 0.0.0.0 --port 8002
+ENABLE_DEMO=true .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8002
 ```
 
 ## Docker イメージのビルドと起動

--- a/lipsync-server/app/api/main.py
+++ b/lipsync-server/app/api/main.py
@@ -2,9 +2,14 @@
 
 from fastapi import APIRouter
 
-from app.api.routes import health, lipsync
+from app.api.routes import demo, health, lipsync
+from app.core.config import settings
 
 api_router = APIRouter(prefix="/api")
 
 api_router.include_router(health.router)
 api_router.include_router(lipsync.router)
+
+demo_router: APIRouter | None = None
+if settings.enable_demo:
+    demo_router = demo.router

--- a/lipsync-server/app/api/routes/demo.py
+++ b/lipsync-server/app/api/routes/demo.py
@@ -1,0 +1,255 @@
+"""デモUIページのルート定義"""
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter(tags=["Demo"])
+
+DEMO_HTML = """
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AnotherMe Lipsync Demo</title>
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                         'Helvetica Neue', Arial, sans-serif;
+            max-width: 640px;
+            margin: 0 auto;
+            padding: 2rem;
+            background: #f5f5f5;
+        }
+        h1 { color: #333; margin-bottom: 1.5rem; }
+        .form-group { margin-bottom: 1.25rem; }
+        label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-weight: 600;
+            color: #444;
+        }
+        input[type="file"] {
+            width: 100%;
+            padding: 0.5rem;
+            border: 2px dashed #ddd;
+            border-radius: 6px;
+            background: #fff;
+            cursor: pointer;
+        }
+        input[type="number"] {
+            width: 100%;
+            padding: 0.75rem;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 1rem;
+        }
+        select {
+            width: 100%;
+            padding: 0.75rem;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 1rem;
+            background: #fff;
+        }
+        button {
+            width: 100%;
+            padding: 1rem;
+            background: #4a90d9;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        button:hover { background: #357abd; }
+        button:disabled { background: #ccc; cursor: not-allowed; }
+        .result {
+            margin-top: 1.5rem;
+            padding: 1rem;
+            background: #fff;
+            border-radius: 6px;
+            border: 1px solid #ddd;
+            display: none;
+        }
+        .result.show { display: block; }
+        .result h3 { margin: 0 0 1rem 0; color: #333; }
+        video { width: 100%; border-radius: 6px; }
+        .meta {
+            margin-top: 0.75rem;
+            font-size: 0.85rem;
+            color: #666;
+        }
+        .download-btn {
+            width: 100%;
+            padding: 0.75rem;
+            background: #28a745;
+            margin-top: 0.75rem;
+        }
+        .download-btn:hover { background: #218838; }
+        .error {
+            color: #dc3545;
+            padding: 1rem;
+            background: #f8d7da;
+            border: 1px solid #f5c6cb;
+            border-radius: 6px;
+            margin-top: 1rem;
+            display: none;
+        }
+        .error.show { display: block; }
+        .loading {
+            text-align: center;
+            color: #666;
+            padding: 1rem;
+            display: none;
+        }
+        .loading.show { display: block; }
+    </style>
+</head>
+<body>
+    <h1>AnotherMe Lipsync Demo</h1>
+
+    <form id="lipsyncForm">
+        <div class="form-group">
+            <label for="audioFile">音声ファイル (WAV/MP3)</label>
+            <input type="file" id="audioFile" accept=".wav,.mp3" required>
+        </div>
+
+        <div class="form-group">
+            <label for="videoFile">動画/画像ファイル (MP4/MOV/JPG/PNG)</label>
+            <input type="file" id="videoFile" accept=".mp4,.mov,.jpg,.png" required>
+        </div>
+
+        <div class="form-group">
+            <label for="bboxShift">BBox Shift</label>
+            <input type="number" id="bboxShift" value="0" min="-50" max="50">
+        </div>
+
+        <div class="form-group">
+            <label for="extraMargin">Extra Margin</label>
+            <input type="number" id="extraMargin" value="10" min="0" max="40">
+        </div>
+
+        <div class="form-group">
+            <label for="parsingMode">Parsing Mode</label>
+            <select id="parsingMode">
+                <option value="jaw" selected>jaw</option>
+                <option value="face">face</option>
+            </select>
+        </div>
+
+        <button type="submit" id="submitBtn">生成</button>
+    </form>
+
+    <div class="loading" id="loading">生成中... (数分かかる場合があります)</div>
+    <div class="error" id="error"></div>
+
+    <div class="result" id="result">
+        <h3>生成結果</h3>
+        <video id="videoPlayer" controls></video>
+        <div class="meta" id="meta"></div>
+        <button class="download-btn" id="downloadBtn">ダウンロード</button>
+    </div>
+
+    <script>
+        const form = document.getElementById('lipsyncForm');
+        const submitBtn = document.getElementById('submitBtn');
+        const loading = document.getElementById('loading');
+        const errorDiv = document.getElementById('error');
+        const resultDiv = document.getElementById('result');
+        const videoPlayer = document.getElementById('videoPlayer');
+        const metaDiv = document.getElementById('meta');
+        const downloadBtn = document.getElementById('downloadBtn');
+
+        let videoBlob = null;
+
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+
+            const audioFile = document.getElementById('audioFile').files[0];
+            const videoFile = document.getElementById('videoFile').files[0];
+            if (!audioFile || !videoFile) {
+                showError('ファイルを選択してください');
+                return;
+            }
+
+            submitBtn.disabled = true;
+            loading.classList.add('show');
+            errorDiv.classList.remove('show');
+            resultDiv.classList.remove('show');
+
+            try {
+                const formData = new FormData();
+                formData.append('audio_file', audioFile);
+                formData.append('video_file', videoFile);
+                formData.append('bbox_shift',
+                    document.getElementById('bboxShift').value);
+                formData.append('extra_margin',
+                    document.getElementById('extraMargin').value);
+                formData.append('parsing_mode',
+                    document.getElementById('parsingMode').value);
+
+                const response = await fetch('/api/lipsync/generate', {
+                    method: 'POST',
+                    body: formData
+                });
+
+                if (!response.ok) {
+                    const err = await response.json();
+                    throw new Error(err.detail || err.error || 'エラーが発生しました');
+                }
+
+                const data = await response.json();
+                const bin = atob(data.video_data);
+                const bytes = new Uint8Array(bin.length);
+                for (let i = 0; i < bin.length; i++) {
+                    bytes[i] = bin.charCodeAt(i);
+                }
+                videoBlob = new Blob([bytes], { type: 'video/mp4' });
+
+                videoPlayer.src = URL.createObjectURL(videoBlob);
+                metaDiv.textContent =
+                    `Duration: ${data.duration_seconds.toFixed(1)}s` +
+                    ` | Processing: ${(data.processing_time_ms / 1000).toFixed(1)}s`;
+                resultDiv.classList.add('show');
+            } catch (err) {
+                showError(err.message);
+            } finally {
+                submitBtn.disabled = false;
+                loading.classList.remove('show');
+            }
+        });
+
+        downloadBtn.addEventListener('click', () => {
+            if (!videoBlob) return;
+            const url = URL.createObjectURL(videoBlob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'lipsync_output.mp4';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
+
+        function showError(msg) {
+            errorDiv.textContent = msg;
+            errorDiv.classList.add('show');
+        }
+    </script>
+</body>
+</html>
+"""
+
+
+@router.get(
+    "/demo",
+    response_class=HTMLResponse,
+    summary="デモUIページ",
+    description="リップシンク生成を試すためのデモUIページを表示します。",
+)
+async def demo_page() -> HTMLResponse:
+    return HTMLResponse(content=DEMO_HTML)

--- a/lipsync-server/app/core/config.py
+++ b/lipsync-server/app/core/config.py
@@ -21,6 +21,9 @@ class Settings(BaseSettings):
     gpu_device: str = "cuda:2"
     max_audio_size_mb: int = 10
     max_video_size_mb: int = 50
+    lipsync_provider: str = "musetalk"
+    use_float16: bool = True
+    batch_size: int = 8
 
 
 settings = Settings()

--- a/lipsync-server/app/core/config.py
+++ b/lipsync-server/app/core/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     provider_name: str = "musetalk"
     use_float16: bool = True
     batch_size: int = 8
+    enable_demo: bool = False
 
 
 settings = Settings()

--- a/lipsync-server/app/lipsync/abc.py
+++ b/lipsync-server/app/lipsync/abc.py
@@ -19,6 +19,13 @@ class LipsyncProvider(ABC):
     このクラスを継承して実装する。
     """
 
+    def load_models(self) -> None:  # noqa: B027
+        """モデルをロードする
+
+        GPU プロバイダーはオーバーライドして重み読み込みを行う。
+        デフォルトは no-op（MockProvider 等はロード不要）。
+        """
+
     @abstractmethod
     async def generate(
         self,

--- a/lipsync-server/app/lipsync/factory.py
+++ b/lipsync-server/app/lipsync/factory.py
@@ -1,5 +1,8 @@
 """リップシンクプロバイダーのファクトリー"""
 
+from pathlib import Path
+
+from app.core.config import settings
 from app.lipsync.abc import LipsyncProvider
 from app.lipsync.mock import MockLipsyncProvider
 
@@ -8,18 +11,28 @@ def create_provider(provider_name: str) -> LipsyncProvider:
     """プロバイダー名からLipsyncProviderインスタンスを生成する
 
     Args:
-        provider_name: プロバイダー名 ("mock" など)
+        provider_name: プロバイダー名 ("mock", "musetalk" など)
 
     Raises:
         ValueError: 不明なプロバイダー名の場合
     """
+    if provider_name == "musetalk":
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        return MuseTalkProvider(
+            device=settings.gpu_device,
+            model_dir=str(
+                Path(__file__).resolve().parents[2] / "submodules" / "MuseTalk"
+            ),
+        )
+
     providers: dict[str, type[LipsyncProvider]] = {
         "mock": MockLipsyncProvider,
     }
 
     provider_class = providers.get(provider_name)
     if provider_class is None:
-        available = ", ".join(sorted(providers.keys()))
+        available = ", ".join(sorted([*providers.keys(), "musetalk"]))
         raise ValueError(
             f"不明なプロバイダー名: {provider_name!r} (利用可能: {available})"
         )

--- a/lipsync-server/app/lipsync/musetalk_provider.py
+++ b/lipsync-server/app/lipsync/musetalk_provider.py
@@ -9,6 +9,8 @@ generate() から run_in_executor で呼び出す。
 from __future__ import annotations
 
 import asyncio
+import copy
+import glob
 import logging
 import os
 import re
@@ -19,6 +21,12 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+
+import cv2
+import imageio
+import numpy as np
+import torch
+from transformers import WhisperModel
 
 from app.lipsync.abc import LipsyncProvider, LipsyncResult
 
@@ -93,6 +101,24 @@ class MuseTalkProvider(LipsyncProvider):
         finally:
             os.chdir(prev_cwd)
 
+    # load_models() でチェックする必須モデルファイル（models/ からの相対パス）
+    _REQUIRED_MODEL_FILES: tuple[str, ...] = (
+        "musetalkV15/unet.pth",
+        "musetalkV15/musetalk.json",
+        "sd-vae/config.json",
+        "sd-vae/diffusion_pytorch_model.bin",
+        "whisper/config.json",
+        "whisper/pytorch_model.bin",
+        "dwpose/dw-ll_ucoco_384.pth",
+        "face-parse-bisent/79999_iter.pth",
+        "face-parse-bisent/resnet18-5c106cde.pth",
+    )
+
+    def _check_model_files(self) -> list[str]:
+        """不足しているモデルファイルの相対パスリストを返す"""
+        models_dir = self._model_dir / "models"
+        return [f for f in self._REQUIRED_MODEL_FILES if not (models_dir / f).exists()]
+
     def load_models(self) -> None:
         """全モデルをロードする（同期メソッド）
 
@@ -100,14 +126,27 @@ class MuseTalkProvider(LipsyncProvider):
         CI 環境でもクラスの import 自体は成功する。
         preprocessing.py がモジュールレベルで相対パスを使って
         init_model() を呼ぶため、CWD を MuseTalk ルートに変更する。
+
+        Raises:
+            FileNotFoundError: 必須モデルファイルが不足している場合
         """
         if self._loaded:
             return
 
+        missing = self._check_model_files()
+        if missing:
+            msg = (
+                "以下のモデルファイルが見つかりません:\n"
+                + "\n".join(f"  - {f}" for f in missing)
+                + "\n\nダウンロードスクリプトを実行してください:\n"
+                "  cd lipsync-server && bash download_weights.sh"
+            )
+            raise FileNotFoundError(msg)
+
         self._setup_sys_path()
 
-        import torch
-
+        # MuseTalk モジュールは pyproject.toml に含まれず、
+        # sys.path 追加 + CWD 変更が前提のため動的 import が必須
         with self._chdir_musetalk():
             from musetalk.utils.audio_processor import AudioProcessor
             from musetalk.utils.blending import get_image
@@ -124,8 +163,6 @@ class MuseTalkProvider(LipsyncProvider):
                 get_video_fps,
                 load_all_model,
             )
-
-        from transformers import WhisperModel
 
         # ユーティリティ関数を保持
         self._get_file_type = get_file_type
@@ -188,13 +225,7 @@ class MuseTalkProvider(LipsyncProvider):
         Returns:
             (動画バイト列, 秒数) のタプル
         """
-        import copy
-        import glob
-
-        import cv2
-        import imageio
-        import numpy as np
-        import torch
+        # moviepy.editor は ffmpeg 依存の重い初期化を含むため関数内 import
         from moviepy.editor import AudioFileClip, VideoFileClip
 
         device = torch.device(self._device)
@@ -393,8 +424,6 @@ class MuseTalkProvider(LipsyncProvider):
         parsing_mode: str,
     ) -> LipsyncResult:
         """同期推論（run_in_executor から呼ばれる）"""
-        import torch
-
         with torch.no_grad():
             video_bytes, duration = self._run_pipeline(
                 audio_path, video_path, bbox_shift, extra_margin, parsing_mode

--- a/lipsync-server/app/lipsync/musetalk_provider.py
+++ b/lipsync-server/app/lipsync/musetalk_provider.py
@@ -146,7 +146,9 @@ class MuseTalkProvider(LipsyncProvider):
         self._setup_sys_path()
 
         # MuseTalk モジュールは pyproject.toml に含まれず、
-        # sys.path 追加 + CWD 変更が前提のため動的 import が必須
+        # sys.path 追加 + CWD 変更が前提のため動的 import が必須。
+        # load_all_model() 内部で os.path.join("models", vae_type) と
+        # 相対パスがハードコードされているため、CWD を維持する。
         with self._chdir_musetalk():
             from musetalk.utils.audio_processor import AudioProcessor
             from musetalk.utils.blending import get_image
@@ -164,6 +166,10 @@ class MuseTalkProvider(LipsyncProvider):
                 load_all_model,
             )
 
+            device = torch.device(self._device)
+
+            vae, unet, pe = load_all_model(device=device)
+
         # ユーティリティ関数を保持
         self._get_file_type = get_file_type
         self._get_video_fps = get_video_fps
@@ -174,16 +180,6 @@ class MuseTalkProvider(LipsyncProvider):
         self._get_bbox_range = get_bbox_range
         self._get_image = get_image
         self._FaceParsing = FaceParsing
-
-        device = torch.device(self._device)
-        models_dir = str(self._model_dir / "models")
-
-        vae, unet, pe = load_all_model(
-            unet_model_path=os.path.join(models_dir, "musetalkV15", "unet.pth"),
-            vae_type="sd-vae",
-            unet_config=os.path.join(models_dir, "musetalkV15", "musetalk.json"),
-            device=device,
-        )
 
         if self._use_float16:
             pe = pe.half()
@@ -202,6 +198,7 @@ class MuseTalkProvider(LipsyncProvider):
         self._pe = pe
         self._timesteps = torch.tensor([0], device=device)
 
+        models_dir = str(self._model_dir / "models")
         whisper_path = os.path.join(models_dir, "whisper")
         self._audio_processor = AudioProcessor(feature_extractor_path=whisper_path)
         whisper = WhisperModel.from_pretrained(whisper_path)
@@ -295,9 +292,15 @@ class MuseTalkProvider(LipsyncProvider):
             )
 
             # --- 前処理 ---
-            coord_list, frame_list = self._get_landmark_and_bbox(
-                input_img_list, bbox_shift
-            )
+            try:
+                coord_list, frame_list = self._get_landmark_and_bbox(
+                    input_img_list, bbox_shift
+                )
+            except ZeroDivisionError:
+                raise ValueError(
+                    "入力画像/動画から顔を検出できませんでした。"
+                    "顔が明瞭に写っているファイルを使用してください。"
+                ) from None
 
             # FaceParsing.model_init() が ./models/face-parse-bisent/ を参照するため
             # CWD を MuseTalk ルートに変更する

--- a/lipsync-server/app/lipsync/musetalk_provider.py
+++ b/lipsync-server/app/lipsync/musetalk_provider.py
@@ -15,6 +15,8 @@ import re
 import sys
 import tempfile
 from argparse import Namespace
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -75,11 +77,29 @@ class MuseTalkProvider(LipsyncProvider):
         if model_dir_str not in sys.path:
             sys.path.insert(0, model_dir_str)
 
+    @contextmanager
+    def _chdir_musetalk(self) -> Iterator[None]:
+        """CWD を MuseTalk ルートに一時変更する
+
+        MuseTalk の preprocessing.py や face_parsing が
+        相対パス（./musetalk/utils/dwpose/... 等）で
+        モデルを参照するため、import 時・実行時に CWD が
+        MuseTalk ルートである必要がある。
+        """
+        prev_cwd = os.getcwd()
+        os.chdir(self._model_dir)
+        try:
+            yield
+        finally:
+            os.chdir(prev_cwd)
+
     def load_models(self) -> None:
         """全モデルをロードする（同期メソッド）
 
         MuseTalk の import をここで動的に行うため、
         CI 環境でもクラスの import 自体は成功する。
+        preprocessing.py がモジュールレベルで相対パスを使って
+        init_model() を呼ぶため、CWD を MuseTalk ルートに変更する。
         """
         if self._loaded:
             return
@@ -87,21 +107,24 @@ class MuseTalkProvider(LipsyncProvider):
         self._setup_sys_path()
 
         import torch
-        from musetalk.utils.audio_processor import AudioProcessor
-        from musetalk.utils.blending import get_image
-        from musetalk.utils.face_parsing import FaceParsing
-        from musetalk.utils.preprocessing import (
-            coord_placeholder,
-            get_bbox_range,
-            get_landmark_and_bbox,
-            read_imgs,
-        )
-        from musetalk.utils.utils import (
-            datagen,
-            get_file_type,
-            get_video_fps,
-            load_all_model,
-        )
+
+        with self._chdir_musetalk():
+            from musetalk.utils.audio_processor import AudioProcessor
+            from musetalk.utils.blending import get_image
+            from musetalk.utils.face_parsing import FaceParsing
+            from musetalk.utils.preprocessing import (
+                coord_placeholder,
+                get_bbox_range,
+                get_landmark_and_bbox,
+                read_imgs,
+            )
+            from musetalk.utils.utils import (
+                datagen,
+                get_file_type,
+                get_video_fps,
+                load_all_model,
+            )
+
         from transformers import WhisperModel
 
         # ユーティリティ関数を保持
@@ -245,10 +268,13 @@ class MuseTalkProvider(LipsyncProvider):
                 input_img_list, bbox_shift
             )
 
-            fp = self._FaceParsing(
-                left_cheek_width=args.left_cheek_width,
-                right_cheek_width=args.right_cheek_width,
-            )
+            # FaceParsing.model_init() が ./models/face-parse-bisent/ を参照するため
+            # CWD を MuseTalk ルートに変更する
+            with self._chdir_musetalk():
+                fp = self._FaceParsing(
+                    left_cheek_width=args.left_cheek_width,
+                    right_cheek_width=args.right_cheek_width,
+                )
 
             input_latent_list = []
             for bbox, frame in zip(coord_list, frame_list, strict=False):

--- a/lipsync-server/app/lipsync/musetalk_provider.py
+++ b/lipsync-server/app/lipsync/musetalk_provider.py
@@ -1,0 +1,406 @@
+"""MuseTalk を利用したリップシンクプロバイダー
+
+MuseTalk は submodules/MuseTalk に配置されており、
+pyproject.toml が存在しないため sys.path 方式で import する。
+GPU 推論はすべて _inference_sync() で同期的に行い、
+generate() から run_in_executor で呼び出す。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import sys
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+from app.lipsync.abc import LipsyncProvider, LipsyncResult
+
+logger = logging.getLogger(__name__)
+
+# デフォルトの MuseTalk サブモジュールパス
+_DEFAULT_MODEL_DIR = Path(__file__).resolve().parents[2] / "submodules" / "MuseTalk"
+
+
+class MuseTalkProvider(LipsyncProvider):
+    """MuseTalk による高品質リップシンク動画生成プロバイダー
+
+    load_models() を呼ぶまでは推論不可。
+    MuseTalk 関連の import は load_models() 内で動的に行い、
+    CI 環境（GPU/MuseTalk 未インストール）でも import エラーにならない。
+    """
+
+    def __init__(
+        self,
+        device: str = "cuda:0",
+        model_dir: str | None = None,
+        use_float16: bool = True,
+        batch_size: int = 8,
+    ) -> None:
+        self._device = device
+        self._model_dir = (
+            Path(model_dir) if model_dir is not None else _DEFAULT_MODEL_DIR
+        )
+        self._use_float16 = use_float16
+        self._batch_size = batch_size
+        self._loaded = False
+
+        # load_models() で初期化される内部状態
+        self._vae: Any = None
+        self._unet: Any = None
+        self._pe: Any = None
+        self._audio_processor: Any = None
+        self._whisper: Any = None
+        self._timesteps: Any = None
+        self._weight_dtype: Any = None
+
+        # MuseTalk のユーティリティ関数（動的 import 後に設定）
+        self._get_file_type: Any = None
+        self._get_video_fps: Any = None
+        self._datagen: Any = None
+        self._get_landmark_and_bbox: Any = None
+        self._read_imgs: Any = None
+        self._coord_placeholder: Any = None
+        self._get_bbox_range: Any = None
+        self._get_image: Any = None
+        self._FaceParsing: Any = None
+
+    def _setup_sys_path(self) -> None:
+        """submodules/MuseTalk を sys.path に追加する（冪等）"""
+        model_dir_str = str(self._model_dir)
+        if model_dir_str not in sys.path:
+            sys.path.insert(0, model_dir_str)
+
+    def load_models(self) -> None:
+        """全モデルをロードする（同期メソッド）
+
+        MuseTalk の import をここで動的に行うため、
+        CI 環境でもクラスの import 自体は成功する。
+        """
+        if self._loaded:
+            return
+
+        self._setup_sys_path()
+
+        import torch
+        from musetalk.utils.audio_processor import AudioProcessor
+        from musetalk.utils.blending import get_image
+        from musetalk.utils.face_parsing import FaceParsing
+        from musetalk.utils.preprocessing import (
+            coord_placeholder,
+            get_bbox_range,
+            get_landmark_and_bbox,
+            read_imgs,
+        )
+        from musetalk.utils.utils import (
+            datagen,
+            get_file_type,
+            get_video_fps,
+            load_all_model,
+        )
+        from transformers import WhisperModel
+
+        # ユーティリティ関数を保持
+        self._get_file_type = get_file_type
+        self._get_video_fps = get_video_fps
+        self._datagen = datagen
+        self._get_landmark_and_bbox = get_landmark_and_bbox
+        self._read_imgs = read_imgs
+        self._coord_placeholder = coord_placeholder
+        self._get_bbox_range = get_bbox_range
+        self._get_image = get_image
+        self._FaceParsing = FaceParsing
+
+        device = torch.device(self._device)
+        models_dir = str(self._model_dir / "models")
+
+        vae, unet, pe = load_all_model(
+            unet_model_path=os.path.join(models_dir, "musetalkV15", "unet.pth"),
+            vae_type="sd-vae",
+            unet_config=os.path.join(models_dir, "musetalkV15", "musetalk.json"),
+            device=device,
+        )
+
+        if self._use_float16:
+            pe = pe.half()
+            vae.vae = vae.vae.half()
+            unet.model = unet.model.half()
+            self._weight_dtype = torch.float16
+        else:
+            self._weight_dtype = torch.float32
+
+        pe = pe.to(device)
+        vae.vae = vae.vae.to(device)
+        unet.model = unet.model.to(device)
+
+        self._vae = vae
+        self._unet = unet
+        self._pe = pe
+        self._timesteps = torch.tensor([0], device=device)
+
+        whisper_path = os.path.join(models_dir, "whisper")
+        self._audio_processor = AudioProcessor(feature_extractor_path=whisper_path)
+        whisper = WhisperModel.from_pretrained(whisper_path)
+        whisper = whisper.to(device=device, dtype=self._weight_dtype).eval()
+        whisper.requires_grad_(False)
+        self._whisper = whisper
+
+        self._loaded = True
+        logger.info("MuseTalk models loaded on %s", self._device)
+
+    def _run_pipeline(
+        self,
+        audio_path: str,
+        video_path: str,
+        bbox_shift: int,
+        extra_margin: int,
+        parsing_mode: str,
+    ) -> tuple[bytes, float]:
+        """MuseTalk 推論パイプラインを実行する
+
+        Returns:
+            (動画バイト列, 秒数) のタプル
+        """
+        import copy
+        import glob
+
+        import cv2
+        import imageio
+        import numpy as np
+        import torch
+        from moviepy.editor import AudioFileClip, VideoFileClip
+
+        device = torch.device(self._device)
+
+        args = Namespace(
+            result_dir="",
+            fps=25,
+            batch_size=self._batch_size,
+            output_vid_name="",
+            use_saved_coord=False,
+            audio_padding_length_left=2,
+            audio_padding_length_right=2,
+            version="v15",
+            extra_margin=extra_margin,
+            parsing_mode=parsing_mode,
+            left_cheek_width=90,
+            right_cheek_width=90,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="musetalk_") as work_dir:
+            temp_dir = os.path.join(work_dir, "v15")
+            os.makedirs(temp_dir, exist_ok=True)
+
+            input_basename = os.path.basename(video_path).split(".")[0]
+            audio_basename = os.path.basename(audio_path).split(".")[0]
+            output_basename = f"{input_basename}_{audio_basename}"
+
+            result_img_save_path = os.path.join(temp_dir, output_basename)
+            os.makedirs(result_img_save_path, exist_ok=True)
+
+            output_vid_path = os.path.join(temp_dir, f"{output_basename}.mp4")
+
+            # --- フレーム抽出 ---
+            if self._get_file_type(video_path) == "video":
+                save_dir_full = os.path.join(temp_dir, input_basename)
+                os.makedirs(save_dir_full, exist_ok=True)
+                reader = imageio.get_reader(video_path)
+                for i, im in enumerate(reader):  # type: ignore[arg-type, var-annotated]
+                    imageio.imwrite(f"{save_dir_full}/{i:08d}.png", im)
+                input_img_list = sorted(
+                    glob.glob(os.path.join(save_dir_full, "*.[jpJP][pnPN]*[gG]"))
+                )
+                fps = self._get_video_fps(video_path)
+            else:
+                input_img_list = glob.glob(
+                    os.path.join(video_path, "*.[jpJP][pnPN]*[gG]")
+                )
+                input_img_list = sorted(
+                    input_img_list,
+                    key=lambda x: int(os.path.splitext(os.path.basename(x))[0]),
+                )
+                fps = args.fps
+
+            # --- 音声特徴抽出 ---
+            whisper_input_features, librosa_length = (
+                self._audio_processor.get_audio_feature(audio_path)
+            )
+            whisper_chunks = self._audio_processor.get_whisper_chunk(
+                whisper_input_features,
+                device,
+                self._weight_dtype,
+                self._whisper,
+                librosa_length,
+                fps=fps,
+                audio_padding_length_left=args.audio_padding_length_left,
+                audio_padding_length_right=args.audio_padding_length_right,
+            )
+
+            # --- 前処理 ---
+            coord_list, frame_list = self._get_landmark_and_bbox(
+                input_img_list, bbox_shift
+            )
+
+            fp = self._FaceParsing(
+                left_cheek_width=args.left_cheek_width,
+                right_cheek_width=args.right_cheek_width,
+            )
+
+            input_latent_list = []
+            for bbox, frame in zip(coord_list, frame_list, strict=False):
+                if bbox == self._coord_placeholder:
+                    continue
+                x1, y1, x2, y2 = bbox
+                y2 = y2 + args.extra_margin
+                y2 = min(y2, frame.shape[0])
+                crop_frame = frame[y1:y2, x1:x2]
+                crop_frame = cv2.resize(
+                    crop_frame, (256, 256), interpolation=cv2.INTER_LANCZOS4
+                )
+                latents = self._vae.get_latents_for_unet(crop_frame)
+                input_latent_list.append(latents)
+
+            # サイクル化（スムージング用）
+            frame_list_cycle = frame_list + frame_list[::-1]
+            coord_list_cycle = coord_list + coord_list[::-1]
+            input_latent_list_cycle = input_latent_list + input_latent_list[::-1]
+
+            # --- 推論 ---
+            gen = self._datagen(
+                whisper_chunks=whisper_chunks,
+                vae_encode_latents=input_latent_list_cycle,
+                batch_size=args.batch_size,
+                delay_frame=0,
+                device=device,
+            )
+
+            res_frame_list: list[Any] = []
+            for whisper_batch, latent_batch in gen:
+                audio_feature_batch = self._pe(whisper_batch)
+                latent_batch = latent_batch.to(dtype=self._weight_dtype)
+                pred_latents = self._unet.model(
+                    latent_batch,
+                    self._timesteps,
+                    encoder_hidden_states=audio_feature_batch,
+                ).sample
+                recon = self._vae.decode_latents(pred_latents)
+                for res_frame in recon:
+                    res_frame_list.append(res_frame)
+
+            # --- ブレンディング + 書き出し ---
+            last_frame = frame_list[-1] if frame_list else None
+            for i, res_frame in enumerate(res_frame_list):
+                bbox = coord_list_cycle[i % len(coord_list_cycle)]
+                ori_frame = copy.deepcopy(frame_list_cycle[i % len(frame_list_cycle)])
+                x1, y1, x2, y2 = bbox
+                y2 = y2 + args.extra_margin
+                frame_ref = last_frame if last_frame is not None else ori_frame
+                y2 = min(y2, frame_ref.shape[0])
+                try:
+                    res_frame = cv2.resize(
+                        res_frame.astype(np.uint8), (x2 - x1, y2 - y1)
+                    )
+                except Exception:
+                    continue
+
+                combine_frame = self._get_image(
+                    ori_frame,
+                    res_frame,
+                    [x1, y1, x2, y2],
+                    mode=args.parsing_mode,
+                    fp=fp,
+                )
+                cv2.imwrite(
+                    f"{result_img_save_path}/{str(i).zfill(8)}.png",
+                    combine_frame,
+                )
+
+            # --- 動画生成 ---
+            pattern = re.compile(r"\d{8}\.png")
+            files = sorted(
+                [f for f in os.listdir(result_img_save_path) if pattern.match(f)],
+                key=lambda x: int(x.split(".")[0]),
+            )
+
+            images: list[Any] = [
+                imageio.imread(os.path.join(result_img_save_path, f))  # type: ignore[no-untyped-call]
+                for f in files
+            ]
+
+            temp_video_path = os.path.join(work_dir, "temp.mp4")
+            imageio.mimwrite(  # type: ignore[call-overload]
+                temp_video_path,
+                images,
+                "FFMPEG",
+                fps=25,
+                codec="libx264",
+                pixelformat="yuv420p",
+            )
+
+            # --- 音声合成 ---
+            video_clip = VideoFileClip(temp_video_path)
+            audio_clip = AudioFileClip(audio_path)
+            video_clip = video_clip.set_audio(audio_clip)
+            video_clip.write_videofile(
+                output_vid_path, codec="libx264", audio_codec="aac", fps=25
+            )
+            video_clip.close()
+            audio_clip.close()
+
+            duration = len(images) / 25.0
+
+            with open(output_vid_path, "rb") as f:
+                video_bytes = f.read()
+
+        return video_bytes, duration
+
+    def _inference_sync(
+        self,
+        audio_path: str,
+        video_path: str,
+        bbox_shift: int,
+        extra_margin: int,
+        parsing_mode: str,
+    ) -> LipsyncResult:
+        """同期推論（run_in_executor から呼ばれる）"""
+        import torch
+
+        with torch.no_grad():
+            video_bytes, duration = self._run_pipeline(
+                audio_path, video_path, bbox_shift, extra_margin, parsing_mode
+            )
+
+        return LipsyncResult(
+            video_bytes=video_bytes,
+            duration_seconds=duration,
+        )
+
+    async def generate(
+        self,
+        audio_path: str,
+        video_path: str,
+        bbox_shift: int = 0,
+        extra_margin: int = 10,
+        parsing_mode: str = "jaw",
+    ) -> LipsyncResult:
+        if not self._loaded:
+            msg = "モデル未ロード: 先に load_models() を呼び出してください"
+            raise RuntimeError(msg)
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            self._inference_sync,
+            audio_path,
+            video_path,
+            bbox_shift,
+            extra_margin,
+            parsing_mode,
+        )
+
+    async def is_ready(self) -> bool:
+        return self._loaded

--- a/lipsync-server/app/main.py
+++ b/lipsync-server/app/main.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.main import api_router
+from app.api.main import api_router, demo_router
 from app.core.config import settings
 from app.lipsync.factory import create_provider
 from app.services.lipsync_service import LipsyncService
@@ -44,6 +44,9 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
     app.include_router(api_router)
+
+    if demo_router is not None:
+        app.include_router(demo_router)
 
     app.add_middleware(
         CORSMiddleware,

--- a/lipsync-server/app/main.py
+++ b/lipsync-server/app/main.py
@@ -27,6 +27,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """アプリケーション起動時の初期化処理"""
     logger.info("リップシンクプロバイダーの初期化を開始します...")
     provider = create_provider(settings.provider_name)
+    provider.load_models()
     app.state.lipsync_service = LipsyncService(provider=provider)
     logger.info(
         "リップシンクプロバイダー(%s)の初期化が完了しました",

--- a/lipsync-server/download_weights.sh
+++ b/lipsync-server/download_weights.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# MuseTalk モデル重みダウンロードスクリプト
+# 公式 MuseTalk/download_weights.sh をベースに、lipsync-server 用に調整。
+# サーバー起動前に実行すること。
+#
+# Usage:
+#   cd lipsync-server
+#   bash download_weights.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODELS_DIR="${SCRIPT_DIR}/submodules/MuseTalk/models"
+
+echo "==> モデル保存先: ${MODELS_DIR}"
+
+# ディレクトリ作成
+mkdir -p \
+  "${MODELS_DIR}/musetalkV15" \
+  "${MODELS_DIR}/sd-vae" \
+  "${MODELS_DIR}/whisper" \
+  "${MODELS_DIR}/dwpose" \
+  "${MODELS_DIR}/face-parse-bisent"
+
+# --- HuggingFace Hub ---
+
+# MuseTalk V1.5
+echo "==> MuseTalk V1.5 weights"
+huggingface-cli download TMElyralab/MuseTalk \
+  --local-dir "${MODELS_DIR}" \
+  --include "musetalkV15/musetalk.json" "musetalkV15/unet.pth"
+
+# Stable Diffusion VAE
+echo "==> SD VAE weights"
+huggingface-cli download stabilityai/sd-vae-ft-mse \
+  --local-dir "${MODELS_DIR}/sd-vae" \
+  --include "config.json" "diffusion_pytorch_model.bin"
+
+# Whisper (Audio Encoder)
+echo "==> Whisper weights"
+huggingface-cli download openai/whisper-tiny \
+  --local-dir "${MODELS_DIR}/whisper" \
+  --include "config.json" "pytorch_model.bin" "preprocessor_config.json"
+
+# DWPose
+echo "==> DWPose weights"
+huggingface-cli download yzd-v/DWPose \
+  --local-dir "${MODELS_DIR}/dwpose" \
+  --include "dw-ll_ucoco_384.pth"
+
+# --- Google Drive / PyTorch Hub ---
+
+# Face Parse BiSeNet
+FACE_PARSE_DIR="${MODELS_DIR}/face-parse-bisent"
+
+if [ ! -f "${FACE_PARSE_DIR}/79999_iter.pth" ]; then
+  echo "==> Face Parse BiSeNet weights (Google Drive)"
+  gdown --id 154JgKpzCPW82qINcVieuPH3fZ2e0P812 \
+    -O "${FACE_PARSE_DIR}/79999_iter.pth"
+else
+  echo "==> Face Parse BiSeNet weights: already exists, skipping"
+fi
+
+if [ ! -f "${FACE_PARSE_DIR}/resnet18-5c106cde.pth" ]; then
+  echo "==> ResNet18 weights (PyTorch Hub)"
+  curl -L https://download.pytorch.org/models/resnet18-5c106cde.pth \
+    -o "${FACE_PARSE_DIR}/resnet18-5c106cde.pth"
+else
+  echo "==> ResNet18 weights: already exists, skipping"
+fi
+
+echo ""
+echo "All weights have been downloaded successfully!"
+echo "Models directory: ${MODELS_DIR}"

--- a/lipsync-server/pyproject.toml
+++ b/lipsync-server/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     "torchvision==0.15.2",
     "transformers==4.39.2",
     "xtcocotools>=1.14.3",
+    # setuptools<70: mmpose/mmengine が pkg_resources を使用するが
+    # setuptools v82+ で削除されたため、pkg_resources を含むバージョンを固定
+    "setuptools<70",
     # --- Server dependencies ---
     "fastapi[standard]>=0.115.0",
     "pydantic-settings>=2.12.0",

--- a/lipsync-server/tests/lipsync/test_musetalk_provider.py
+++ b/lipsync-server/tests/lipsync/test_musetalk_provider.py
@@ -1,0 +1,467 @@
+"""MuseTalkProvider の単体テスト (CI互換: GPU不要、MuseTalk import モック)"""
+
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.lipsync.abc import LipsyncProvider, LipsyncResult
+
+
+# ---------------------------------------------------------------------------
+# MuseTalk モジュールのスタブ群（CI環境にtorch/MuseTalkが無い場合に備える）
+# ---------------------------------------------------------------------------
+def _build_musetalk_stubs() -> dict[str, ModuleType]:
+    """musetalk.* 名前空間のスタブモジュールを生成する"""
+    stubs: dict[str, ModuleType] = {}
+
+    # musetalk
+    musetalk = ModuleType("musetalk")
+    stubs["musetalk"] = musetalk
+
+    # musetalk.utils
+    musetalk_utils = ModuleType("musetalk.utils")
+    stubs["musetalk.utils"] = musetalk_utils
+
+    # musetalk.utils.utils
+    utils_utils = ModuleType("musetalk.utils.utils")
+    mock_models = (MagicMock(), MagicMock(), MagicMock())
+    utils_utils.load_all_model = MagicMock(return_value=mock_models)  # type: ignore[attr-defined]
+    utils_utils.get_file_type = MagicMock(return_value="video")  # type: ignore[attr-defined]
+    utils_utils.get_video_fps = MagicMock(return_value=25)  # type: ignore[attr-defined]
+    utils_utils.datagen = MagicMock(return_value=iter([]))  # type: ignore[attr-defined]
+    stubs["musetalk.utils.utils"] = utils_utils
+
+    # musetalk.utils.preprocessing
+    preprocessing = ModuleType("musetalk.utils.preprocessing")
+    preprocessing.get_landmark_and_bbox = MagicMock(return_value=([], []))  # type: ignore[attr-defined]
+    preprocessing.read_imgs = MagicMock(return_value=[])  # type: ignore[attr-defined]
+    preprocessing.coord_placeholder = (-1, -1, -1, -1)  # type: ignore[attr-defined]
+    preprocessing.get_bbox_range = MagicMock(return_value="")  # type: ignore[attr-defined]
+    stubs["musetalk.utils.preprocessing"] = preprocessing
+
+    # musetalk.utils.blending
+    blending = ModuleType("musetalk.utils.blending")
+    blending.get_image = MagicMock()  # type: ignore[attr-defined]
+    stubs["musetalk.utils.blending"] = blending
+
+    # musetalk.utils.face_parsing
+    face_parsing = ModuleType("musetalk.utils.face_parsing")
+    face_parsing.FaceParsing = MagicMock()  # type: ignore[attr-defined]
+    stubs["musetalk.utils.face_parsing"] = face_parsing
+
+    # musetalk.utils.audio_processor
+    audio_processor = ModuleType("musetalk.utils.audio_processor")
+    audio_processor.AudioProcessor = MagicMock()  # type: ignore[attr-defined]
+    stubs["musetalk.utils.audio_processor"] = audio_processor
+
+    return stubs
+
+
+# ---------------------------------------------------------------------------
+# torch スタブ（CI環境に torch が無い場合）
+# ---------------------------------------------------------------------------
+def _build_torch_stub() -> ModuleType:
+    """最低限の torch スタブを生成する"""
+    torch_mod = ModuleType("torch")
+    torch_mod.device = MagicMock  # type: ignore[attr-defined]
+    torch_mod.float16 = "float16"  # type: ignore[attr-defined]
+    torch_mod.float32 = "float32"  # type: ignore[attr-defined]
+    ctx = MagicMock(__enter__=MagicMock(), __exit__=MagicMock())
+    torch_mod.no_grad = MagicMock(return_value=ctx)  # type: ignore[attr-defined]
+    torch_mod.tensor = MagicMock()  # type: ignore[attr-defined]
+    torch_mod.cuda = MagicMock()  # type: ignore[attr-defined]
+    torch_mod.cuda.is_available = MagicMock(return_value=False)
+    return torch_mod
+
+
+def _build_transformers_stub() -> ModuleType:
+    """最低限の transformers スタブを生成する"""
+    transformers_mod = ModuleType("transformers")
+    mock_whisper = MagicMock()
+    mock_whisper.from_pretrained = MagicMock(return_value=MagicMock())
+    transformers_mod.WhisperModel = mock_whisper  # type: ignore[attr-defined]
+    return transformers_mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture()
+def musetalk_stubs() -> dict[str, ModuleType]:
+    return _build_musetalk_stubs()
+
+
+@pytest.fixture()
+def _patch_musetalk_imports(
+    musetalk_stubs: dict[str, ModuleType],
+) -> Generator[None, None, None]:
+    """sys.modules に MuseTalk スタブを注入し、テスト後に復元する"""
+    torch_stub = _build_torch_stub()
+    transformers_stub = _build_transformers_stub()
+
+    all_stubs: dict[str, Any] = {
+        **musetalk_stubs,
+        "torch": torch_stub,
+        "torch.cuda": MagicMock(),
+        "transformers": transformers_stub,
+    }
+
+    originals: dict[str, Any] = {}
+    for name, mod in all_stubs.items():
+        originals[name] = sys.modules.get(name)
+        sys.modules[name] = mod
+
+    yield
+
+    for name in all_stubs:
+        if originals[name] is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = originals[name]
+
+
+# ---------------------------------------------------------------------------
+# テストクラス
+# ---------------------------------------------------------------------------
+class TestMuseTalkProviderInit:
+    """__init__ のパラメータ検証"""
+
+    @pytest.mark.unit
+    def test_init_default_values(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        assert provider._device == "cuda:0"
+        assert provider._use_float16 is True
+        assert provider._batch_size == 8
+        assert provider._loaded is False
+
+    @pytest.mark.unit
+    def test_init_custom_values(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(
+            device="cuda:1",
+            model_dir="/custom/path",
+            use_float16=False,
+            batch_size=4,
+        )
+        assert provider._device == "cuda:1"
+        assert provider._model_dir == Path("/custom/path")
+        assert provider._use_float16 is False
+        assert provider._batch_size == 4
+
+    @pytest.mark.unit
+    def test_model_dir_defaults_to_submodules(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        expected = Path(__file__).resolve().parents[2] / "submodules" / "MuseTalk"
+        assert provider._model_dir == expected
+
+    @pytest.mark.unit
+    def test_is_subclass_of_lipsync_provider(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        assert issubclass(MuseTalkProvider, LipsyncProvider)
+
+
+class TestMuseTalkProviderIsReady:
+    """is_ready() の状態テスト"""
+
+    @pytest.mark.unit
+    async def test_is_ready_false_before_load(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        assert await provider.is_ready() is False
+
+    @pytest.mark.unit
+    @pytest.mark.usefixtures("_patch_musetalk_imports")
+    async def test_is_ready_true_after_load(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        provider.load_models()
+        assert await provider.is_ready() is True
+
+
+class TestMuseTalkProviderSysPath:
+    """_setup_sys_path のテスト"""
+
+    @pytest.mark.unit
+    def test_setup_sys_path_adds_model_dir(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(model_dir="/fake/musetalk")
+        original_path = sys.path.copy()
+
+        try:
+            provider._setup_sys_path()
+            assert "/fake/musetalk" in sys.path
+        finally:
+            sys.path[:] = original_path
+
+    @pytest.mark.unit
+    def test_setup_sys_path_idempotent(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(model_dir="/fake/musetalk2")
+        original_path = sys.path.copy()
+
+        try:
+            provider._setup_sys_path()
+            provider._setup_sys_path()
+            count = sys.path.count("/fake/musetalk2")
+            assert count == 1
+        finally:
+            sys.path[:] = original_path
+
+
+class TestMuseTalkProviderLoadModels:
+    """load_models() のテスト（MuseTalk import をモック）"""
+
+    @pytest.mark.unit
+    @pytest.mark.usefixtures("_patch_musetalk_imports")
+    def test_load_models_sets_loaded_flag(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        assert provider._loaded is False
+        provider.load_models()
+        assert provider._loaded is True
+
+    @pytest.mark.unit
+    @pytest.mark.usefixtures("_patch_musetalk_imports")
+    def test_load_models_sets_internal_attributes(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        provider.load_models()
+
+        assert provider._vae is not None
+        assert provider._unet is not None
+        assert provider._pe is not None
+        assert provider._audio_processor is not None
+        assert provider._whisper is not None
+        assert provider._timesteps is not None
+
+    @pytest.mark.unit
+    @pytest.mark.usefixtures("_patch_musetalk_imports")
+    def test_load_models_idempotent(self) -> None:
+        """load_models() を2回呼んでも問題ない"""
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        provider.load_models()
+        provider.load_models()
+        assert provider._loaded is True
+
+
+class TestMuseTalkProviderGenerate:
+    """generate() のテスト"""
+
+    @pytest.mark.unit
+    async def test_generate_raises_when_not_loaded(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        with pytest.raises(RuntimeError, match="load_models"):
+            await provider.generate(
+                audio_path="/tmp/test.wav",
+                video_path="/tmp/test.mp4",
+            )
+
+    @pytest.mark.unit
+    @pytest.mark.usefixtures("_patch_musetalk_imports")
+    async def test_generate_calls_inference_sync_in_executor(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        provider.load_models()
+
+        fake_result = LipsyncResult(
+            video_bytes=b"\x00\x00\x00\x1c\x66\x74\x79\x70",
+            duration_seconds=2.5,
+        )
+
+        with patch.object(
+            provider, "_inference_sync", return_value=fake_result
+        ) as mock_sync:
+            result = await provider.generate(
+                audio_path="/tmp/test.wav",
+                video_path="/tmp/test.mp4",
+                bbox_shift=5,
+                extra_margin=15,
+                parsing_mode="face",
+            )
+
+            mock_sync.assert_called_once_with(
+                "/tmp/test.wav", "/tmp/test.mp4", 5, 15, "face"
+            )
+            assert result is fake_result
+
+    @pytest.mark.unit
+    @pytest.mark.usefixtures("_patch_musetalk_imports")
+    async def test_generate_returns_lipsync_result(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        provider.load_models()
+
+        fake_result = LipsyncResult(
+            video_bytes=b"fakevideo",
+            duration_seconds=1.0,
+        )
+
+        with patch.object(provider, "_inference_sync", return_value=fake_result):
+            result = await provider.generate(
+                audio_path="/tmp/test.wav",
+                video_path="/tmp/test.mp4",
+            )
+
+            assert isinstance(result, LipsyncResult)
+            assert result.video_bytes == b"fakevideo"
+            assert result.duration_seconds == 1.0
+
+    @pytest.mark.unit
+    @pytest.mark.usefixtures("_patch_musetalk_imports")
+    async def test_generate_default_parameters(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        provider.load_models()
+
+        fake_result = LipsyncResult(video_bytes=b"data", duration_seconds=0.5)
+
+        with patch.object(
+            provider, "_inference_sync", return_value=fake_result
+        ) as mock_sync:
+            await provider.generate(
+                audio_path="/tmp/a.wav",
+                video_path="/tmp/v.mp4",
+            )
+
+            mock_sync.assert_called_once_with("/tmp/a.wav", "/tmp/v.mp4", 0, 10, "jaw")
+
+
+class TestMuseTalkProviderInferenceSync:
+    """_inference_sync() の内部ロジックテスト（重い処理はすべてモック）"""
+
+    @pytest.mark.unit
+    @pytest.mark.usefixtures("_patch_musetalk_imports")
+    def test_inference_sync_returns_lipsync_result(self, tmp_path: Path) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider()
+        provider.load_models()
+
+        # _run_pipeline をモックして MP4 バイト列を返す
+        fake_bytes = b"\x00\x00\x00\x1c\x66\x74\x79\x70\x69\x73\x6f\x6d"
+        with patch.object(provider, "_run_pipeline", return_value=(fake_bytes, 2.0)):
+            result = provider._inference_sync(
+                str(tmp_path / "test.wav"),
+                str(tmp_path / "test.mp4"),
+                0,
+                10,
+                "jaw",
+            )
+
+        assert isinstance(result, LipsyncResult)
+        assert result.video_bytes == fake_bytes
+        assert result.duration_seconds == 2.0
+
+
+class TestMuseTalkProviderFactoryIntegration:
+    """factory.py との統合テスト"""
+
+    @pytest.mark.integration
+    def test_factory_creates_musetalk_provider(self) -> None:
+        from app.lipsync.factory import create_provider
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        with patch("app.lipsync.factory.settings") as mock_settings:
+            mock_settings.gpu_device = "cuda:0"
+            provider = create_provider("musetalk")
+
+        assert isinstance(provider, MuseTalkProvider)
+
+    @pytest.mark.integration
+    def test_factory_still_creates_mock_provider(self) -> None:
+        from app.lipsync.factory import create_provider
+        from app.lipsync.mock import MockLipsyncProvider
+
+        provider = create_provider("mock")
+        assert isinstance(provider, MockLipsyncProvider)
+
+    @pytest.mark.integration
+    def test_factory_unknown_provider_raises(self) -> None:
+        from app.lipsync.factory import create_provider
+
+        with pytest.raises(ValueError, match="不明なプロバイダー名"):
+            create_provider("nonexistent")
+
+
+class TestMuseTalkProviderConfig:
+    """config.py に追加された設定値のテスト"""
+
+    @pytest.mark.unit
+    def test_settings_has_lipsync_provider(self) -> None:
+        from app.core.config import Settings
+
+        s = Settings()
+        assert hasattr(s, "lipsync_provider")
+        assert s.lipsync_provider == "musetalk"
+
+    @pytest.mark.unit
+    def test_settings_has_use_float16(self) -> None:
+        from app.core.config import Settings
+
+        s = Settings()
+        assert hasattr(s, "use_float16")
+        assert s.use_float16 is True
+
+    @pytest.mark.unit
+    def test_settings_has_batch_size(self) -> None:
+        from app.core.config import Settings
+
+        s = Settings()
+        assert hasattr(s, "batch_size")
+        assert s.batch_size == 8
+
+
+# ---------------------------------------------------------------------------
+# GPU テスト (CI除外)
+# ---------------------------------------------------------------------------
+class TestMuseTalkProviderGPU:
+    """GPU環境でのみ実行するテスト"""
+
+    @pytest.mark.gpu
+    def test_load_models_on_gpu(self) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(device="cuda:0")
+        provider.load_models()
+        assert provider._loaded is True
+
+    @pytest.mark.gpu
+    async def test_generate_with_real_data(self, tmp_path: Path) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(device="cuda:0")
+        provider.load_models()
+
+        # 実際のテストデータが必要
+        audio_path = str(tmp_path / "test.wav")
+        video_path = str(tmp_path / "test.mp4")
+        result = await provider.generate(
+            audio_path=audio_path,
+            video_path=video_path,
+        )
+        assert isinstance(result, LipsyncResult)
+        assert len(result.video_bytes) > 0
+        assert result.duration_seconds > 0

--- a/lipsync-server/tests/lipsync/test_musetalk_provider.py
+++ b/lipsync-server/tests/lipsync/test_musetalk_provider.py
@@ -1,5 +1,6 @@
 """MuseTalkProvider の単体テスト (CI互換: GPU不要、MuseTalk import モック)"""
 
+import os
 import sys
 from collections.abc import Generator
 from pathlib import Path
@@ -220,6 +221,37 @@ class TestMuseTalkProviderSysPath:
             assert count == 1
         finally:
             sys.path[:] = original_path
+
+
+class TestMuseTalkProviderChdirMusetalk:
+    """_chdir_musetalk() コンテキストマネージャーのテスト"""
+
+    @pytest.mark.unit
+    def test_chdir_changes_to_model_dir(self, tmp_path: Path) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(model_dir=str(tmp_path))
+        original_cwd = os.getcwd()
+
+        with provider._chdir_musetalk():
+            assert os.getcwd() == str(tmp_path)
+
+        assert os.getcwd() == original_cwd
+
+    @pytest.mark.unit
+    def test_chdir_restores_on_exception(self, tmp_path: Path) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(model_dir=str(tmp_path))
+        original_cwd = os.getcwd()
+
+        with pytest.raises(RuntimeError, match="test error"):
+            with provider._chdir_musetalk():
+                assert os.getcwd() == str(tmp_path)
+                msg = "test error"
+                raise RuntimeError(msg)
+
+        assert os.getcwd() == original_cwd
 
 
 class TestMuseTalkProviderLoadModels:

--- a/lipsync-server/tests/lipsync/test_musetalk_provider.py
+++ b/lipsync-server/tests/lipsync/test_musetalk_provider.py
@@ -11,9 +11,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from app.lipsync.abc import LipsyncProvider, LipsyncResult
 
+_MODULE = "app.lipsync.musetalk_provider"
+
 
 # ---------------------------------------------------------------------------
-# MuseTalk モジュールのスタブ群（CI環境にtorch/MuseTalkが無い場合に備える）
+# MuseTalk モジュールのスタブ群（CI環境にMuseTalkが無い場合に備える）
 # ---------------------------------------------------------------------------
 def _build_musetalk_stubs() -> dict[str, ModuleType]:
     """musetalk.* 名前空間のスタブモジュールを生成する"""
@@ -62,30 +64,30 @@ def _build_musetalk_stubs() -> dict[str, ModuleType]:
     return stubs
 
 
-# ---------------------------------------------------------------------------
-# torch スタブ（CI環境に torch が無い場合）
-# ---------------------------------------------------------------------------
-def _build_torch_stub() -> ModuleType:
-    """最低限の torch スタブを生成する"""
-    torch_mod = ModuleType("torch")
-    torch_mod.device = MagicMock  # type: ignore[attr-defined]
-    torch_mod.float16 = "float16"  # type: ignore[attr-defined]
-    torch_mod.float32 = "float32"  # type: ignore[attr-defined]
+def _build_torch_mock() -> MagicMock:
+    """load_models() 用の torch モックを生成する
+
+    CI 環境に CUDA が無いため、torch.device / torch.tensor 等を
+    MagicMock で差し替える。
+    """
+    mock_torch = MagicMock()
+    mock_torch.device = MagicMock
+    mock_torch.float16 = "float16"
+    mock_torch.float32 = "float32"
     ctx = MagicMock(__enter__=MagicMock(), __exit__=MagicMock())
-    torch_mod.no_grad = MagicMock(return_value=ctx)  # type: ignore[attr-defined]
-    torch_mod.tensor = MagicMock()  # type: ignore[attr-defined]
-    torch_mod.cuda = MagicMock()  # type: ignore[attr-defined]
-    torch_mod.cuda.is_available = MagicMock(return_value=False)
-    return torch_mod
+    mock_torch.no_grad = MagicMock(return_value=ctx)
+    mock_torch.tensor = MagicMock()
+    return mock_torch
 
 
-def _build_transformers_stub() -> ModuleType:
-    """最低限の transformers スタブを生成する"""
-    transformers_mod = ModuleType("transformers")
-    mock_whisper = MagicMock()
-    mock_whisper.from_pretrained = MagicMock(return_value=MagicMock())
-    transformers_mod.WhisperModel = mock_whisper  # type: ignore[attr-defined]
-    return transformers_mod
+def _build_whisper_mock() -> MagicMock:
+    """load_models() 用の WhisperModel モックを生成する
+
+    CI 環境にモデルファイルが無いため、from_pretrained をモックする。
+    """
+    mock_cls = MagicMock()
+    mock_cls.from_pretrained.return_value = MagicMock()
+    return mock_cls
 
 
 # ---------------------------------------------------------------------------
@@ -99,26 +101,31 @@ def musetalk_stubs() -> dict[str, ModuleType]:
 @pytest.fixture()
 def _patch_musetalk_imports(
     musetalk_stubs: dict[str, ModuleType],
+    tmp_path: Path,
 ) -> Generator[None, None, None]:
-    """sys.modules に MuseTalk スタブを注入し、テスト後に復元する"""
-    torch_stub = _build_torch_stub()
-    transformers_stub = _build_transformers_stub()
+    """MuseTalk スタブ + torch/WhisperModel モックを注入する
 
-    all_stubs: dict[str, Any] = {
-        **musetalk_stubs,
-        "torch": torch_stub,
-        "torch.cuda": MagicMock(),
-        "transformers": transformers_stub,
-    }
-
+    musetalk.* — sys.modules に直接注入（パッケージが存在しないため）
+    torch, WhisperModel — モジュールレベル参照を patch で差し替え
+    """
+    # musetalk スタブを sys.modules に注入
     originals: dict[str, Any] = {}
-    for name, mod in all_stubs.items():
+    for name, mod in musetalk_stubs.items():
         originals[name] = sys.modules.get(name)
         sys.modules[name] = mod
 
-    yield
+    mock_torch = _build_torch_mock()
+    mock_whisper = _build_whisper_mock()
 
-    for name in all_stubs:
+    with (
+        patch(f"{_MODULE}.torch", mock_torch),
+        patch(f"{_MODULE}.WhisperModel", mock_whisper),
+        patch(f"{_MODULE}._DEFAULT_MODEL_DIR", tmp_path),
+        patch(f"{_MODULE}.MuseTalkProvider._check_model_files", return_value=[]),
+    ):
+        yield
+
+    for name in musetalk_stubs:
         if originals[name] is None:
             sys.modules.pop(name, None)
         else:
@@ -464,6 +471,42 @@ class TestMuseTalkProviderConfig:
         s = Settings()
         assert hasattr(s, "batch_size")
         assert s.batch_size == 8
+
+
+# ---------------------------------------------------------------------------
+# モデルファイル存在チェック
+# ---------------------------------------------------------------------------
+class TestMuseTalkProviderModelCheck:
+    """_check_model_files / load_models のモデル存在チェックテスト"""
+
+    @pytest.mark.unit
+    def test_check_model_files_all_missing(self, tmp_path: Path) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(model_dir=str(tmp_path))
+        missing = provider._check_model_files()
+        assert len(missing) == len(MuseTalkProvider._REQUIRED_MODEL_FILES)
+
+    @pytest.mark.unit
+    def test_check_model_files_all_present(self, tmp_path: Path) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        models_dir = tmp_path / "models"
+        for f in MuseTalkProvider._REQUIRED_MODEL_FILES:
+            path = models_dir / f
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"dummy")
+
+        provider = MuseTalkProvider(model_dir=str(tmp_path))
+        assert provider._check_model_files() == []
+
+    @pytest.mark.unit
+    def test_load_models_raises_when_files_missing(self, tmp_path: Path) -> None:
+        from app.lipsync.musetalk_provider import MuseTalkProvider
+
+        provider = MuseTalkProvider(model_dir=str(tmp_path))
+        with pytest.raises(FileNotFoundError, match="download_weights.sh"):
+            provider.load_models()
 
 
 # ---------------------------------------------------------------------------

--- a/lipsync-server/uv.lock
+++ b/lipsync-server/uv.lock
@@ -80,6 +80,7 @@ dependencies = [
     { name = "pydantic-settings", marker = "sys_platform == 'linux'" },
     { name = "python-multipart", marker = "sys_platform == 'linux'" },
     { name = "requests", marker = "sys_platform == 'linux'" },
+    { name = "setuptools", marker = "sys_platform == 'linux'" },
     { name = "soundfile", marker = "sys_platform == 'linux'" },
     { name = "tensorboard", marker = "sys_platform == 'linux'" },
     { name = "tensorflow", marker = "sys_platform == 'linux'" },
@@ -126,6 +127,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "setuptools", specifier = "<70" },
     { name = "soundfile", specifier = "==0.12.1" },
     { name = "tensorboard", specifier = "==2.12.0" },
     { name = "tensorflow", specifier = "==2.12.0" },
@@ -1942,11 +1944,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.0"
+version = "69.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987", size = 2291314, upload-time = "2024-04-13T21:06:28.589Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/29/13965af254e3373bceae8fb9a0e6ea0d0e571171b80d6646932131d6439b/setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32", size = 894566, upload-time = "2024-04-13T21:06:23.256Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **MuseTalkProvider**: MuseTalk推論をラップした `LipsyncProvider` 実装（`musetalk_provider.py` 460行）
  - `load_models()` でモデル一括ロード、`generate()` で `run_in_executor` 経由の非同期推論
  - MuseTalk の相対パス問題を `_chdir_musetalk()` コンテキストマネージャーで解決
  - `load_all_model()` も CWD コンテキスト内で実行（VAE パスがハードコードされているため）
  - 顔未検出時の `ZeroDivisionError` を `ValueError` に変換し適切なエラーメッセージを返却
  - `musetalk.*` のみ動的 import（sys.path + CWD 依存）、他は全て先頭 import
  - 起動時にモデルファイル存在チェック（`_check_model_files`）、不足時は `FileNotFoundError`
- **ABC 拡張**: `LipsyncProvider` に `load_models()` メソッド追加（no-op デフォルト）
- **main.py**: lifespan 内で `provider.load_models()` を呼び出し
- **factory.py**: `"musetalk"` プロバイダーを遅延 import で登録
- **config.py**: `provider_name`, `use_float16`, `batch_size`, `enable_demo` 設定追加
- **デモ UI**: `/demo` エンドポイント（`enable_demo=true` で有効化）
- **download_weights.sh**: MuseTalk モデル重みの一括ダウンロードスクリプト
- **pyproject.toml**: `setuptools<70` 追加（mmpose/mmengine の pkg_resources 依存対応）
- **README.md**: セットアップ手順 + 依存関係トラブルシューティング
  - `uv run` ではなく `.venv/bin/` を使用（uv が lockfile 外パッケージを削除するため）
  - OpenMMLab は `mim install` で別途インストール（CUDA 固有ビルドが必要）

## Test plan

- [x] `uv run ruff check / format` — lint 通過
- [x] `uv run mypy app/` — 型チェック通過
- [x] `uv run pytest -m "not gpu" --cov` — 75テスト全通過、カバレッジ98%
- [x] `.venv/bin/uvicorn` でサーバー起動確認（MuseTalk モデルロード成功）
- [ ] `.venv/bin/pytest -m gpu -v` — GPU 推論テスト
- [ ] デモ UI からリップシンク生成の E2E 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)