### PR TITLE
feat: lipsync-server Dockerfile + .dockerignore

### DIFF
--- a/lipsync-server/.dockerignore
+++ b/lipsync-server/.dockerignore
@@ -1,0 +1,62 @@
+# Python cache
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/*.so
+.Python
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+*.coverage.*
+
+# Development files
+*.log
+.env
+.env.*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Documentation
+*.md
+
+# Scripts
+scripts/
+
+# Docker
+dockerfile
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+
+# Pre-commit
+.pre-commit-config.yaml
+
+# MuseTalk models (ボリュームマウントで提供)
+submodules/MuseTalk/models/
+submodules/MuseTalk/results/

--- a/lipsync-server/dockerfile
+++ b/lipsync-server/dockerfile
@@ -1,0 +1,35 @@
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install -y \
+    locales \
+    curl \
+    ffmpeg \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen ja_JP.UTF-8 && update-locale LANG=ja_JP.UTF-8
+
+ENV LANG=ja_JP.UTF-8 \
+    LANGUAGE=ja_JP:ja \
+    LC_ALL=ja_JP.UTF-8
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:$PATH"
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock .python-version ./
+
+RUN uv sync --frozen --no-cache
+
+COPY app ./app
+COPY submodules ./submodules
+
+EXPOSE 8002
+
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002"]


### PR DESCRIPTION
## Summary
- NVIDIA CUDA 11.8ベースの Dockerfile を作成（torch==2.0.1+cu118 に合致）
- ffmpeg / libgl1-mesa-glx / libglib2.0-0 をインストール（MuseTalk + OpenCV 依存）
- `.dockerignore` でビルドコンテキストを最適化（モデル重み除外）
- モデルは実行時にボリュームマウントで提供

## Test plan
- [ ] `docker build -t lipsync-server .` でビルド成功を確認
- [ ] `docker run --gpus all -v /path/to/models:/app/submodules/MuseTalk/models -p 8002:8002 lipsync-server` で起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)